### PR TITLE
Update data.py--fixing logic that causes TypeError

### DIFF
--- a/fusion_bench/utils/data.py
+++ b/fusion_bench/utils/data.py
@@ -96,7 +96,7 @@ def train_validation_split(
 
     # Compute the number of samples for training and validation
     num_samples = len(dataset)
-    if validation_size is not None:
+    if validation_size is None:
         assert (
             0 < validation_fraction < 1
         ), "Validation fraction must be between 0 and 1"


### PR DESCRIPTION
Apparent wrong logic in line 99-- train_validation_split() asserts that exactly one of {validation_size, validation_fraction} is None; however, the statements here try to compare the one that is None with a number.

Resulting error:
Error in call to target 'fusion_bench.utils.data.train_validation_split': TypeError("'<' not supported between instances of 'NoneType' and 'int'")