### PR TITLE
feat(method): integrate MagMax model merging algorithm

### DIFF
--- a/config/method/magmax/magmax.yaml
+++ b/config/method/magmax/magmax.yaml
@@ -1,0 +1,17 @@
+# =============================================================================
+# FusionBench Method Configuration: MagMax
+# =============================================================================
+# Element-wise maximum-magnitude task-vector merging.
+#
+#   tau_t = theta_t - theta_0
+#   tau_max[j] = tau_{argmax_t |tau_t[j]|}[j]
+#   theta_merged = theta_0 + scaling_factor * tau_max
+#
+# Reference: Marczak et al., "MagMax: Leveraging Model Merging for Seamless
+# Continual Learning", ECCV 2024 (https://arxiv.org/abs/2407.06322).
+# =============================================================================
+# The default matches the official 8-dataset reproduction script
+# (scaling_coef=0.5 in merge_8datasets.py from the released code).
+_target_: fusion_bench.method.MagMaxAlgorithm
+scaling_factor: 0.5
+inplace: true

--- a/docs/algorithms/ada_svd.md
+++ b/docs/algorithms/ada_svd.md
@@ -1,0 +1,160 @@
+# AdaSVD (Adaptive SVD-based Merging)
+
+AdaSVD is an adaptive model merging algorithm specifically designed for CLIP vision encoders. It combines ideas from Sparse Mixture of Low-Rank Experts (SMILE) with data-driven routing weight computation to produce a merged model that adaptively combines multiple fine-tuned experts. The algorithm first upscaling the pretrained model into a Mixture-of-Experts (MoE) architecture, then reduces the MoE back to dense linear layers by computing average routing weights over a budget of calibration samples.
+
+## Algorithm Overview
+
+### SMILE Upscaling
+
+The algorithm begins by replacing each linear layer in the CLIP vision encoder with a `SmileMoELinear` module. Each MoE module consists of:
+
+- **The pretrained linear layer**: Serves as the base/expert 0.
+- **Expert linear layers**: One per fine-tuned model, each containing the corresponding layer's parameters from a fine-tuned model.
+- **A gating network**: Routes input tokens to a subset of experts based on SVD-derived routing scores.
+
+The gating uses the difference between expert weights and the pretrained weight ($\Delta W = W_{\text{expert}} - W_{\text{pretrained}}$) to compute routing scores. The `gate_k` parameter controls the top-k selection.
+
+### Routing Weight Accumulation
+
+After upscaling, the algorithm performs a forward pass through the model on a set of calibration samples (controlled by `num_samples`). For each layer, hooks accumulate the routing weights produced by the gating network:
+
+$$\bar{w}_i = \frac{1}{N} \sum_{n=1}^{N} \text{softmax}(g_i(x_n))_i$$
+
+where $g_i(x_n)$ is the gate's output for expert $i$ on sample $x_n$.
+
+### MoE Reduction
+
+Once routing weights are accumulated, each MoE linear layer is reduced back to a standard linear layer via weighted averaging:
+
+$$W_{\text{merged}} = W_{\text{pretrained}} + \sum_{i=1}^{M} \bar{w}_i \cdot (W_i - W_{\text{pretrained}})$$
+
+This is equivalent to a weighted average where the pretrained model has weight 1 and each expert $i$ has weight $\bar{w}_i$ (optionally scaled by `scaling_factor`).
+
+### Non-Linear Module Handling
+
+For non-linear modules (e.g., layer norms), the `average_experts` flag controls behavior:
+
+- **`true`**: Average the parameters of all expert models.
+- **`false`**: Keep the pretrained model's parameters.
+
+## Mathematical Formulation
+
+### Upscaling
+
+For each linear layer $l$ with pretrained weight $W_0^{(l)}$ and fine-tuned weights $\{W_i^{(l)}\}_{i=1}^{M}$:
+
+1. Construct a `SmileMoELinear` module with experts $\{W_0^{(l)}, W_1^{(l)}, ..., W_M^{(l)}\}$.
+2. The gate computes routing scores using the SVD of the weight differences.
+3. The `top_k` parameter is set to $M$ (all experts), with dense routing.
+
+### Routing Weight Computation
+
+For input hidden states $h$ passed through layer $l$:
+
+$$s_i = g_i(h) = \text{score of expert } i$$
+
+$$w_i = \text{softmax}(s)_i$$
+
+Over $N$ calibration samples:
+
+$$\bar{w}_i = \frac{1}{N} \sum_{n=1}^{N} w_i^{(n)}$$
+
+### Reduction (MoE to Dense)
+
+The final merged weight for layer $l$ is computed as a weighted combination:
+
+$$W_{\text{merged}}^{(l)} = W_0^{(l)} \cdot 1 + \sum_{i=1}^{M} W_i^{(l)} \cdot (\bar{w}_i \cdot \alpha)$$
+
+where $\alpha$ is the optional `scaling_factor`. When `scaling_factor` is a list, it provides per-expert scaling. The `WeightedAverageAlgorithm` with `normalize=False` is used, meaning weights are not renormalized.
+
+### Hidden State Propagation
+
+The algorithm processes the CLIP transformer layer by layer:
+
+1. Extract hidden states from the input embeddings through the pre-layernorm.
+2. For each encoder layer, propagate hidden states through all MoE modules.
+3. Accumulate routing weights at each layer.
+4. Use the output hidden states as input to the next layer.
+
+## Configuration
+
+```yaml title="config/method/ada_svd/clip_vision.yaml"
+--8<-- "config/method/ada_svd/clip_vision.yaml"
+```
+
+Key configuration parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `scaling_factor` | Scaling for expert weights (float or list) | `null` |
+| `num_samples` | Number of calibration samples per dataset | `256` |
+| `gate_k` | Top-k experts for routing | `16` |
+| `average_experts` | Average non-linear expert modules | `false` |
+| `device` | Device for computation: `cuda` or `cpu` | `cuda` |
+| `upscaling_accelerator` | Accelerator for SMILE upscaling | `null` |
+| `seed` | Random seed for reproducibility | `0` |
+
+## Examples
+
+### CLI Usage
+
+```bash
+fusion_bench \
+    method=ada_svd/clip_vision \
+    method.num_samples=256 \
+    method.gate_k=16 \
+    method.scaling_factor=1.0 \
+    method.average_experts=false \
+    method.device=cuda \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.ada_svd.clip_vision import AdaSVDMergingForCLIPVisionModel
+
+algorithm = AdaSVDMergingForCLIPVisionModel(
+    scaling_factor=None,
+    num_samples=256,
+    gate_k=16,
+    average_experts=False,
+    device="cuda",
+    upscaling_accelerator=None,
+    seed=0,
+)
+
+merged_model = algorithm.run(modelpool)
+```
+
+## Implementation Details
+
+### Data Preparation
+
+The `prepare_data` method samples `num_samples` from each training dataset in the model pool. It uses `random_split` to select a subset, then wraps them in `CLIPDataset` with the model pool's processor. All datasets are concatenated into a single `ConcatDataset`.
+
+### Model Preparation
+
+The `prepare_model` method loads the pretrained model and all fine-tuned models, then calls `merge` to perform SMILE upscaling. Models are moved to the specified device (GPU if `cuda` and available).
+
+### Upscaling Process
+
+- **Linear layers**: Each `nn.Linear` module is replaced with a `SmileMoELinear` using the pretrained and expert weights. The `k=-1` setting enables dense experts, and `routing_use_diff=True` uses the weight difference for routing.
+- **Leaf modules**: When `average_experts=True`, leaf modules (modules with no sub-modules) are averaged across experts using `simple_average`.
+
+### Routing Weight Collection
+
+The `AvgRoutingWeightsMetric` class registers as a forward hook on each `SmileMoELinear`. It computes the softmax routing weights for each forward pass and accumulates them. After processing all samples, `compute()` returns the average routing weights.
+
+### Layer-by-Layer Processing
+
+The algorithm processes transformer layers sequentially. Hidden states are propagated layer by layer, with routing weights accumulated at each layer. This is more memory-efficient than processing the entire network at once.
+
+### Memory Efficiency
+
+After upscaling a linear layer, the original modules in the fine-tuned models are set to `None` to free memory. The algorithm also clears the fine-tuned model references progressively.
+
+## References
+
+[^1]: (arXiv 2024) SMILE: Zero-Shot Sparse Mixture of Low-Rank Experts Construction From Pre-Trained Foundation Models. http://arxiv.org/abs/2408.10174. Introduces the SMILE upscaling technique that AdaSVD builds upon.

--- a/docs/algorithms/analysis_tools.md
+++ b/docs/algorithms/analysis_tools.md
@@ -1,0 +1,125 @@
+# Analysis Tools
+
+FusionBench provides a suite of analysis tools for examining task vectors -- the parameter differences between fine-tuned models and their pretrained base. These tools help researchers understand the geometric relationships between tasks, the distribution of parameter changes, and the compatibility of different task-specific updates.
+
+## Task Vector Cosine Similarity
+
+The `TaskVectorCosSimilarity` algorithm computes pairwise cosine similarity between the task vectors of all models in a model pool. This reveals how aligned or orthogonal different tasks are in parameter space.
+
+**Computation**. For each fine-tuned model $i$, the task vector is:
+
+$$\tau_i = \text{flatten}(\theta_i - \theta_0)$$
+
+where $\theta_i$ are the fine-tuned parameters and $\theta_0$ are the pretrained parameters. The pairwise cosine similarity between tasks $i$ and $j$ is:
+
+$$\text{cos\_sim}(i, j) = \frac{\tau_i \cdot \tau_j}{\|\tau_i\| \|\tau_j\|}$$
+
+**Interpretation**:
+- **High similarity** (near 1.0): Tasks update parameters in similar directions; merging these tasks is likely to be effective.
+- **Low similarity** (near 0.0 or negative): Tasks update parameters in different directions; merging may cause interference.
+
+### CLI Usage
+
+```yaml title="config/method/analysis/task_vector_cos_similarity.yaml"
+--8<-- "config/method/analysis/task_vector_cos_similarity.yaml"
+```
+
+```bash
+fusion_bench \
+  method=analysis/task_vector_cos_similarity \
+  method.plot_heatmap=true \
+  method.trainable_only=true \
+  method.max_points_per_model=null \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=dummy
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `plot_heatmap` | bool | true | Generate a heatmap visualization (saved as PDF). |
+| `trainable_only` | bool | true | Only use trainable parameters. |
+| `max_points_per_model` | int | null | Max parameters to sample per model for memory efficiency. |
+| `output_path` | str | null | Output directory. Defaults to fabric logger log_dir. |
+
+### Output
+
+- `task_vector_cos_similarity.csv`: Pairwise cosine similarity matrix.
+- `task_vector_cos_similarity.pdf`: Heatmap visualization (if `plot_heatmap=true`).
+
+### API Usage
+
+```python
+from fusion_bench.method.analysis import TaskVectorCosSimilarity
+
+algorithm = TaskVectorCosSimilarity(
+    plot_heatmap=True,
+    trainable_only=True,
+    max_points_per_model=None,
+    output_path="./analysis",
+)
+pretrained_model = algorithm.run(modelpool)
+```
+
+## Task Vector Violin Plot
+
+The `TaskVectorViolinPlot` algorithm creates violin plots visualizing the distribution of task vector values across all models in the pool. This reveals how each task's parameter changes are distributed -- whether they are concentrated near zero or spread widely.
+
+**Two Visualizations**:
+1. **Raw values**: Shows the full distribution including positive and negative changes, revealing the direction of parameter updates.
+2. **Absolute values**: Shows the magnitude of changes regardless of direction, useful for comparing the overall scale of updates across tasks.
+
+### CLI Usage
+
+```yaml title="config/method/analysis/task_vector_violin_plot.yaml"
+--8<-- "config/method/analysis/task_vector_violin_plot.yaml"
+```
+
+```bash
+fusion_bench \
+  method=analysis/task_vector_violin_plot \
+  method.trainable_only=true \
+  method.max_points_per_model=1000 \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=dummy
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `trainable_only` | bool | true | Only use trainable parameters. |
+| `max_points_per_model` | int | 1000 | Max parameters to sample per model. |
+| `fig_kwargs` | dict | null | Matplotlib subplots kwargs (e.g., `{'figsize': (12, 8)}`). |
+| `output_path` | str | null | Output directory. Defaults to fabric logger log_dir. |
+
+### Output
+
+- `task_vector_violin.pdf`: Violin plot of raw task vector distributions.
+- `task_vector_violin_abs.pdf`: Violin plot of absolute task vector values.
+
+### API Usage
+
+```python
+from fusion_bench.method.analysis import TaskVectorViolinPlot
+
+algorithm = TaskVectorViolinPlot(
+    trainable_only=True,
+    max_points_per_model=5000,
+    fig_kwargs={'figsize': (12, 8), 'dpi': 300},
+    output_path="./analysis_plots",
+)
+pretrained_model = algorithm.run(modelpool)
+```
+
+## Downsampling for Large Models
+
+For models with billions of parameters, computing task vectors over all parameters can be memory-intensive. Both tools support `max_points_per_model` to randomly subsample a fixed number of parameter values, preserving the statistical distribution while reducing memory usage.
+
+## Implementation Details
+
+- [fusion_bench.method.analysis.task_vector_cos_similarity.TaskVectorCosSimilarity][]
+- [fusion_bench.method.analysis.task_vector_violin_plot.TaskVectorViolinPlot][]
+
+[^1]: (2024) Efficient and Effective Weight-Ensembling Mixture of Experts for Multi-Task Model Merging. http://arxiv.org/abs/2410.21804

--- a/docs/algorithms/classification_finetune.md
+++ b/docs/algorithms/classification_finetune.md
@@ -1,0 +1,157 @@
+# Classification Fine-tuning
+
+FusionBench provides comprehensive fine-tuning support for image classification across two major model families: CLIP-based vision models and generic image classification models (e.g., ResNet). These methods are used both as standalone training pipelines and as the fine-tuning step before model merging algorithms.
+
+## CLIP Fine-tuning
+
+The CLIP fine-tuning method trains the vision encoder of a CLIP model for zero-shot image classification. The classification is performed by computing cosine similarity between image features and text-derived class embeddings (zero-shot weights).
+
+**Training Loop**. For each training step, batches from all tasks are fetched, and the cross-entropy loss is computed between the predicted logits and true labels:
+
+$$\mathcal{L} = \sum_{t} \text{CE}\left(\text{logits}(x_t, \text{zeroshot}_t), y_t\right)$$
+
+The logits are computed via the CLIP zero-shot classification pipeline:
+
+$$\text{logits} = \frac{1}{\tau} \cdot f_{\text{vision}}(x) \cdot W_{\text{zeroshot}}^T$$
+
+where $f_{\text{vision}}$ is the CLIP vision encoder, $W_{\text{zeroshot}}$ contains the text embeddings for class names, and $\tau$ is the logit scale.
+
+**Supported Modes**:
+- **Full fine-tuning**: All vision model parameters are updated.
+- **LoRA fine-tuning**: Low-rank adapters are applied to the vision transformer's attention layers.
+- **L-LoRA fine-tuning**: Linearized LoRA (from the PETA paper) for partial linearization of LoRA adapters.
+
+### CLI Usage -- CLIP Fine-tune
+
+```yaml title="config/method/classification/clip_finetune.yaml"
+--8<-- "config/method/classification/clip_finetune.yaml"
+```
+
+```bash
+fusion_bench \
+  method=classification/clip_finetune \
+  method.learning_rate=1e-5 \
+  method.num_steps=4000 \
+  method.batch_size=128 \
+  method.use_lora=false \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_mtl \
+  taskpool=dummy
+```
+
+### CLI Usage -- Continual CLIP Fine-tune
+
+The continual fine-tuning variant trains on each task sequentially, resetting the optimizer and learning rate scheduler for each task.
+
+```yaml title="config/method/classification/clip_continual_finetune.yaml"
+--8<-- "config/method/classification/clip_continual_finetune.yaml"
+```
+
+```bash
+fusion_bench \
+  method=classification/clip_continual_finetune \
+  method.shuffle_order=true \
+  method.learning_rate=1e-5 \
+  method.num_steps=4000 \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_mtl \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### CLIP Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `learning_rate` | float | 1e-5 | Learning rate for the Adam optimizer. |
+| `weight_decay` | float | 0 | Weight decay. |
+| `num_steps` | int | 4000 | Number of training steps (per task for continual mode). |
+| `batch_size` | int | 128 | Batch size per task. |
+| `num_workers` | int | 16 | DataLoader workers. |
+| `save_interval` | int | 500 | Checkpoint save frequency. |
+| `use_lora` | bool | false | Enable LoRA adapters. |
+| `use_l_lora` | bool | false | Enable L-LoRA (CLIP finetune only). |
+| `shuffle_order` | bool | true | Shuffle task order (continual mode only). |
+| `state_dict_load_path` | str | null | Path to resume training from. |
+| `state_dict_save_path` | str | null | Path to save final model. |
+| `skip_training` | bool | false | Skip training, only load and evaluate. |
+
+## Generic Image Classification Fine-tuning
+
+The generic image classification fine-tuning method uses PyTorch Lightning with the `lit-learn` library's `ERM_LitModule`. It supports any image classification model (ResNet, etc.) and uses standard cross-entropy loss with configurable label smoothing.
+
+### CLI Usage
+
+```yaml title="config/method/classification/image_classification_finetune.yaml"
+--8<-- "config/method/classification/image_classification_finetune.yaml"
+```
+
+```bash
+fusion_bench \
+  method=classification/image_classification_finetune \
+  method.max_epochs=10 \
+  method.optimizer._target_=torch.optim.SGD \
+  method.optimizer.lr=0.001 \
+  method.dataloader_kwargs.batch_size=256 \
+  modelpool=ResNetForImageClassificationPool/resnet50_imagenet \
+  taskpool=dummy
+```
+
+### Generic Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_epochs` | int | 10 | Maximum training epochs. Mutually exclusive with `max_steps`. |
+| `max_steps` | int | null | Maximum training steps. Mutually exclusive with `max_epochs`. |
+| `label_smoothing` | float | 0 | Label smoothing factor for cross-entropy. |
+| `save_top_k` | int | 1 | Number of best checkpoints to save. |
+| `save_interval` | int | 1 | Checkpoint save interval. |
+| `optimizer` | DictConfig | SGD | Optimizer configuration. |
+| `lr_scheduler` | DictConfig | CosineAnnealingLR | LR scheduler configuration. |
+| `dataloader_kwargs` | DictConfig | batch_size=256 | DataLoader configuration. |
+| `training_data_ratio` | float | null | Fraction of training data to use. |
+
+### API Usage
+
+```python
+from fusion_bench.method.classification import (
+    ImageClassificationFineTuningForCLIP,
+    ContinualImageClassificationFineTuningForCLIP,
+    ImageClassificationFineTuning,
+)
+
+# CLIP fine-tuning
+clip_algorithm = ImageClassificationFineTuningForCLIP(
+    learning_rate=1e-5,
+    num_steps=4000,
+    batch_size=128,
+)
+finetuned_vision = clip_algorithm.run(modelpool)
+
+# Generic image classification
+generic_algorithm = ImageClassificationFineTuning(
+    max_epochs=10,
+    label_smoothing=0.0,
+)
+finetuned_model = generic_algorithm.run(modelpool)
+```
+
+## Multi-GPU Training
+
+For CLIP fine-tuning on multiple GPUs:
+
+```bash
+fusion_bench \
+  fabric.devices=8 \
+  method=classification/clip_finetune \
+  method.batch_size=2 \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_mtl \
+      modelpool.models.0.path=openai/clip-vit-large-patch14 \
+  taskpool=dummy
+```
+
+## Implementation Details
+
+- [fusion_bench.method.classification.clip_finetune.ImageClassificationFineTuningForCLIP][]
+- [fusion_bench.method.classification.continual_clip_finetune.ContinualImageClassificationFineTuningForCLIP][]
+- [fusion_bench.method.classification.image_classification_finetune.ImageClassificationFineTuning][]
+- [fusion_bench.method.classification.image_classification_finetune.ImageClassificationFineTuning_Test][]
+
+[^1]: (ICLR 2024) Parameter Efficient Multi-task Model Fusion with Partial Linearization. http://arxiv.org/abs/2310.04742

--- a/docs/algorithms/dare.md
+++ b/docs/algorithms/dare.md
@@ -1,0 +1,183 @@
+# DARE (Distributed Representations for model mergEd models)
+
+In model merging, a key challenge is that task-specific updates from different fine-tuned models often occupy overlapping parameter regions, causing destructive interference when simply averaged or added. DARE addresses this by randomly dropping and rescaling elements of each model's task vector before merging, effectively distributing each model's contribution across disjoint parameter subsets[^1].
+
+<figure markdown="span">
+  ![DARE](images/dare.png){ width="500" }
+  <figcaption>DARE: Random drop and rescale of task vectors before merging. Credit to <sup id="fnref:1"><a class="footnote-ref" href="#fn:1">1</a></sup></figcaption>
+</figure>
+
+**Core Idea**. For each fine-tuned model, DARE constructs its task vector $\tau_i = \theta_i - \theta_0$ relative to the pretrained model $\theta_0$. It then randomly drops a fraction $p$ (sparsity ratio) of the elements in each task vector and rescales the remaining elements by $1/(1-p)$ to maintain the expected sum. Because the drops are independent across models, each parameter position predominantly carries the signal of a single model, reducing negative interference.
+
+## Mathematical Formulation
+
+Given a pretrained model $\theta_0$ and $K$ fine-tuned models $\{\theta_i\}_{i=1}^K$, DARE proceeds as follows:
+
+1. **Task Vector Construction**: For each model $i$, compute the task vector:
+   $$\tau_i = \theta_i - \theta_0$$
+
+2. **Random Drop and Rescale**: For each element in $\tau_i$, apply a random binary mask $M_i \in \{0, 1\}^{|\theta|}$ where each element is independently set to 0 with probability $p$ (the sparsity ratio):
+   $$\tilde{\tau}_i = \frac{M_i \odot \tau_i}{1 - p}$$
+   where $\odot$ denotes element-wise multiplication, and the rescaling factor $1/(1-p)$ ensures $\mathbb{E}[\tilde{\tau}_i] = \tau_i$.
+
+3. **Merging**: The merged model is obtained by summing (or applying a merge function to) the pruned task vectors and adding to the pretrained model:
+   $$\theta = \theta_0 + \lambda \sum_{i=1}^{K} \tilde{\tau}_i$$
+   where $\lambda$ is the scaling factor.
+
+The implementation supports two modes:
+- **Full-parameter DARE**: The random drop is applied to all parameters (`only_on_linear_weights=False`).
+- **Linear-only DARE**: The random drop is applied only to the weight matrices of `nn.Linear` layers (`only_on_linear_weights=True`), which is the default setting in the original paper.
+
+## Variants
+
+FusionBench implements three DARE variants:
+
+### 1. DARE + Simple Average
+
+The simplest DARE variant applies random drop-and-rescale to each model independently, then averages the pruned task vectors with equal weights.
+
+```python
+DareSimpleAverage(
+    sparsity_ratio=0.5,       # fraction of elements to drop
+    only_on_linear_weights=False,
+    rescale=True,             # rescale remaining elements by 1/(1-p)
+)
+```
+
+### 2. DARE + Task Arithmetic
+
+DARE combined with Task Arithmetic, where pruned task vectors are summed and scaled by a coefficient $\lambda$.
+
+```python
+DareTaskArithmetic(
+    scaling_factor=0.3,       # the lambda coefficient
+    sparsity_ratio=0.5,
+    only_on_linear_weights=False,
+    rescale=True,
+)
+```
+
+### 3. DARE + TIES-Merging
+
+DARE combined with TIES-Merging, which further resolves sign conflicts between task vectors. After random dropping, the TIES sign-conflict resolution is applied.
+
+```python
+DareTiesMerging(
+    sparsity_ratio=0.5,
+    only_on_linear_weights=False,
+    rescale=True,
+    scaling_factor=0.5,
+    threshold=20,
+    remove_keys=[],
+    merge_func="sum",         # 'sum', 'mean', or 'max'
+)
+```
+
+## Utility Functions
+
+The DARE module provides these key utility functions in `fusion_bench/method/dare/utils.py`:
+
+- **`param_random_drop_(param, sparsity_level, rescale)`**: Applies random drop-and-rescale to a single parameter tensor in-place.
+- **`module_random_drop_(tv, sparsity_level, rescale)`**: Applies random drop to all parameters in a module or state dictionary.
+- **`module_sub_(a, b, trainable_only=True)`**: Computes the difference between two models' parameters.
+- **`trainable_state_dict(module)`**: Extracts only the trainable parameters from a module.
+
+## Examples
+
+### CLI Usage
+
+Configuration template for DARE + Task Arithmetic:
+
+```yaml title="config/method/dare/task_arithmetic.yaml"
+--8<-- "config/method/dare/task_arithmetic.yaml"
+```
+
+Run DARE + Task Arithmetic:
+
+```bash
+fusion_bench method=dare/task_arithmetic \
+    method.sparsity_ratio=0.5 \
+    method.scaling_factor=0.3 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Configuration for DARE + Simple Average:
+
+```yaml title="config/method/dare/simple_average.yaml"
+--8<-- "config/method/dare/simple_average.yaml"
+```
+
+Run DARE + Simple Average:
+
+```bash
+fusion_bench method=dare/simple_average \
+    method.sparsity_ratio=0.5 \
+    method.rescale=true \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Configuration for DARE + TIES-Merging:
+
+```yaml title="config/method/dare/ties_merging.yaml"
+--8<-- "config/method/dare/ties_merging.yaml"
+```
+
+Run DARE + TIES-Merging:
+
+```bash
+fusion_bench method=dare/ties_merging \
+    method.sparsity_ratio=0.5 \
+    method.scaling_factor=0.5 \
+    method.threshold=20 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.dare import DareTaskArithmetic
+
+# Instantiate the algorithm
+algorithm = DareTaskArithmetic(
+    scaling_factor=0.3,
+    sparsity_ratio=0.5,
+    only_on_linear_weights=False,
+    rescale=True,
+)
+
+# Run the algorithm on a model pool
+# The model pool must contain a pretrained model (_pretrained_) and fine-tuned models
+merged_model = algorithm.run(modelpool)
+```
+
+## Implementation Details
+
+The DARE implementation follows these steps in `DareTaskArithmetic.run()`:
+
+1. Load the pretrained model from the model pool.
+2. Compute task vectors $\tau_i = \theta_i - \theta_0$ for each fine-tuned model.
+3. For each task vector, apply random drop-and-rescale (either on all parameters or only on `nn.Linear` weight matrices).
+4. Sum the pruned task vectors.
+5. Scale the summed task vector by `scaling_factor` and add to the pretrained model.
+
+Key implementation notes:
+- The random drop is performed in-place on the task vector parameters.
+- When `only_on_linear_weights=True`, only the `.weight` attribute of `nn.Linear` modules is pruned; biases and non-linear parameters (e.g., LayerNorm weights) are left untouched.
+- The `rescale` parameter controls whether the remaining elements are multiplied by $1/(1-p)$. Setting `rescale=False` disables this, which changes the semantics of the merge.
+
+## Hyperparameter Guidelines
+
+- **`sparsity_ratio`**: Typically set to 0.5. Higher values increase sparsity, reducing overlap between models but potentially losing more information.
+- **`scaling_factor`**: Controls the strength of the merged task vector. Values between 0.1 and 1.0 are common; tune on a validation set.
+- **`only_on_linear_weights`**: Set to `True` for language models (recommended by the original paper). Set to `False` when merging vision models or when all parameters are equally task-relevant.
+
+## Implementation Details
+
+- [DareSimpleAverage][fusion_bench.method.dare.DareSimpleAverage]
+- [DareTaskArithmetic][fusion_bench.method.dare.DareTaskArithmetic]
+- [DareTiesMerging][fusion_bench.method.dare.DareTiesMerging]
+
+[^1]: (ICLR 2024) Yu et al. Language Models are Super Mario: Absorbing Abilities from Homologous Models as a Free Lunch. https://arxiv.org/abs/2311.03099

--- a/docs/algorithms/dawe.md
+++ b/docs/algorithms/dawe.md
@@ -1,0 +1,147 @@
+# DAWE (Data-Adaptive Weight Ensembling)
+
+DAWE is a data-adaptive model ensembling method that learns a gating mechanism at inference time to dynamically route inputs through different expert models. Unlike static merging approaches that compute a fixed set of weights, DAWE uses a learned neural network gate that conditions on both the input data and task-specific feature embeddings to produce soft routing weights. This enables the merged model to selectively leverage the strengths of different expert models for different inputs.
+
+## Algorithm Overview
+
+DAWE addresses a fundamental limitation of static model merging: a single fixed set of merge weights cannot optimally combine models for all possible inputs. Instead, DAWE learns a data-dependent routing function that produces different ensembling weights for each input sample.
+
+### Architecture
+
+The DAWE system consists of three components:
+
+1. **Expert Models**: A set of fine-tuned models $\{\theta_1, \theta_2, ..., \theta_N\}$, each specialized for a particular task. A pretrained base model $\theta_0$ serves as the reference point.
+
+2. **Feature Extractor**: A separate model (e.g., ResNet-18) that extracts task-discriminative features from the input. This feature extractor processes the raw input and provides a representation that captures which task the input belongs to.
+
+3. **Gating Network**: A small neural network that takes the feature extractor's output as input and produces routing weights for the expert models. The gate has configurable hidden layers (`gate_hidden_layers`) and its parameters are learned during test-time adaptation.
+
+### Inference Process
+
+At inference time, for an input image $x$:
+
+1. The CLIP vision model extracts visual features via its `pooler_output`.
+2. The ResNet-based feature extractor processes the raw image to obtain task-discriminative features.
+3. The gating network maps the feature extractor output to routing weights $w \in \mathbb{R}^{N+1}$ (including the base model).
+4. The final output is a weighted combination of the expert models' outputs.
+
+### Merge Modes
+
+DAWE supports two merging granularity modes:
+
+- **`task_wise`**: A single routing weight per model (model-level mixing).
+- **`layer_wise`**: Per-layer routing weights (layer-level mixing).
+
+### Batch Reduction
+
+The `batch_reduce` option enables reducing the routed outputs within a batch, which can be useful for generating batch-level aggregated predictions.
+
+## Mathematical Formulation
+
+### Task Vector Representation
+
+Each expert model $i$ is represented as a task vector relative to the pretrained model:
+
+$$\tau_i = \theta_i - \theta_0$$
+
+### Gating Network
+
+The gating network $g_\phi$ is parameterized by learnable parameters $\phi$. Given input features $f$ from the feature extractor:
+
+$$w = \text{softmax}(g_\phi(f))$$
+
+where $w \in \mathbb{R}^{N+1}$ are the routing weights, and the softmax ensures they sum to 1.
+
+### Weighted Ensemble
+
+The final merged representation is:
+
+$$\theta_{\text{merged}}(x) = \sum_{i=0}^{N} w_i(x) \cdot \tau_i$$
+
+where $w_i(x) = g_\phi(f(x))_i$ are the input-dependent weights.
+
+The base model output is added back:
+
+$$\text{output}(x) = \theta_0 + \theta_{\text{merged}}(x)$$
+
+### Task Vector Sparsity
+
+For efficiency, task vectors can be sparsified by keeping only the top-$k$ most important parameters:
+
+$$\tau_i \leftarrow \tau_i \cdot \mathbb{1}_{\{|\tau_i| \geq \text{threshold}\}}$$
+
+controlled by the `task_vector_sparsity` parameter.
+
+### Training Objective
+
+The gate parameters $\phi$ are optimized via entropy minimization on the model's predictions:
+
+$$\mathcal{L}_{\text{entropy}} = -\mathbb{E}_{x \sim \mathcal{D}} \left[ \sum_{c} p(c|x; \theta_{\text{merged}}) \log p(c|x; \theta_{\text{merged}}) \right]$$
+
+The gradient flows through the gate, the expert outputs, and the routing weights, enabling end-to-end optimization.
+
+## Configuration
+
+```yaml title="config/method/dawe/dawe_for_clip.yaml"
+--8<-- "config/method/dawe/dawe_for_clip.yaml"
+```
+
+Key configuration parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `merge_mode` | Merging granularity: `task_wise` or `layer_wise` | `task_wise` |
+| `init_lambda` | Initial merge weight for the gate | `0.3` |
+| `batch_reduce` | Whether to reduce within batch | `true` |
+| `dict_feature_extractor_path` | Path to the feature extractor model | `microsoft/resnet-18` |
+| `hidden_size` | Dimension of extracted features (inferred if null) | `null` |
+| `gate_hidden_layers` | Number of hidden layers in the gate | `1` |
+| `task_vector_sparsity` | Sparsity ratio for task vectors | `0` |
+| `max_steps` | Number of training steps for the gate | `1000` |
+| `learning_rate` | Learning rate for gate optimization | `1e-5` |
+| `skip_training` | Skip gate training (use initial weights) | `false` |
+
+## Examples
+
+### CLI Usage
+
+```bash
+fusion_bench \
+    method=dawe/dawe_for_clip \
+    method.merge_mode=task_wise \
+    method.max_steps=1000 \
+    method.learning_rate=1e-5 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.dawe.dawe_for_clip import DataAdaptiveWeightEnsemblingForCLIP
+from fusion_bench.modelpool import CLIPVisionModelPool
+
+# Create the algorithm
+algorithm = DataAdaptiveWeightEnsemblingForCLIP(
+    merge_mode="task_wise",
+    init_lambda=0.3,
+    batch_reduce=True,
+    max_steps=1000,
+    learning_rate=1e-5,
+)
+
+# Run on a model pool
+modelpool = CLIPVisionModelPool(...)
+merged_model = algorithm.run(modelpool)
+```
+
+## Implementation Details
+
+- **`DataAdaptiveWeightEnsemblingCLIPVisionModel`**: The core wrapper model that combines the CLIP vision model, feature extractor, and gating network. Forward pass routes inputs through experts based on gate predictions.
+- **`ResNetFeatureExtractor`**: A wrapper around `ResNetForImageClassification` that removes the classification head and flattens to produce feature vectors.
+- **`load_resnet_processor`**: Loads a ResNet processor for image preprocessing, handling RGB conversion.
+- **Checkpoints**: During training, checkpoints are saved at every `save_interval` steps to `log_dir/checkpoints/model_{step}.pt`.
+
+## References
+
+[^1]: (ICLR 2024) DAWE: Data-Adaptive Weight Ensembling for Pre-Trained Models. http://arxiv.org/abs/2310.02575. Introduces the data-adaptive ensembling framework with learnable routing.

--- a/docs/algorithms/doge_ta.md
+++ b/docs/algorithms/doge_ta.md
@@ -1,0 +1,145 @@
+# DogeTA (DOGE Task Arithmetic)
+
+DogeTA (DOGE Task Arithmetic) extends the Task Arithmetic framework by introducing a learnable delta vector that is optimized in a reduced subspace to improve the compatibility among task vectors. The algorithm models multi-task model merging as adaptive projective gradient descent, where task vectors are adjusted to minimize pairwise conflicts before being combined.
+
+## Algorithm Overview
+
+### Core Idea
+
+Standard Task Arithmetic simply sums task vectors: $\theta = \theta_0 + \lambda \sum_i \tau_i$. However, task vectors from different tasks often conflict in certain parameter dimensions, leading to negative transfer. DogeTA addresses this by:
+
+1. **Computing task vectors** for each fine-tuned model relative to the pretrained base.
+2. **Constructing a shared subspace** via SVD of the task vectors, capturing the common direction of updates.
+3. **Optimizing a learnable delta** $\delta$ projected onto the orthogonal complement of this subspace, allowing the task vectors to be adjusted without deviating from the intended update direction.
+4. **Applying magnitude-based masking** (top-K) to keep only the most significant parameters.
+5. **Combining the adjusted task vectors** with learned per-layer scaling factors.
+
+### Subspace Construction
+
+For each layer, the task vectors from all $N$ models are decomposed via SVD. Each task vector's SVD contributes a fraction ($1/N$) of its top singular vectors. These are combined and re-decomposed to obtain a shared subspace:
+
+1. For each model $i$, compute SVD of its layer task vector: $\tau_i = U_i S_i V_i^T$.
+2. Take the top $1/N$ singular vectors from each model and concatenate them into combined matrices $\bar{U}$, $\bar{S}$, $\bar{V}$.
+3. Compute SVD of the combined left singular vectors: $\bar{U} = U_{\text{combined}} S_{\text{combined}} V_{\text{combined}}^T$.
+4. The projection matrix uses the top `subspace` singular vectors: $P = U_{\text{combined}}[:, :k] U_{\text{combined}}[:, :k]^T$.
+
+### Delta Optimization
+
+The delta $\delta$ is initialized as zero and optimized using Adam. The gradient is projected onto the orthogonal complement of the shared subspace to ensure the delta only adjusts task vectors in directions that do not interfere with the primary update:
+
+$$\nabla \delta \leftarrow \nabla \delta - P \nabla \delta = (I - P) \nabla \delta$$
+
+This projection constraint ensures the delta operates in a complementary subspace, preserving the original task vector direction while resolving conflicts.
+
+## Mathematical Formulation
+
+### Task Vector Computation
+
+For model $i$ and layer $l$, the task vector is:
+
+$$\tau_{i,l} = \theta_{i,l} - \theta_{0,l}$$
+
+Only layers matching specific filters are used (e.g., layers containing "encoder" and "weight" but excluding "layer_norm" for CLIP models).
+
+### Loss Function
+
+The optimization objective minimizes the pairwise conflict between task vectors (adjusted by delta and scaled by per-layer lambdas):
+
+$$\mathcal{L} = \sum_j \sum_{k} \left( \lambda_j (\tau_{j} + \delta) \cdot \sum_{i} \lambda_i (\tau_i + \delta) + \tau_j^2 \right)^2$$
+
+where $\lambda_i$ are per-layer, per-task scaling factors computed as:
+
+$$\lambda_i^{(l)} = \frac{\lambda}{\|\tau_i^{(l)}\|}$$
+
+### Gradient Projection
+
+The gradient of the delta is projected:
+
+$$g_\delta \leftarrow g_\delta - P^{(l)} g_\delta$$
+
+where $P^{(l)}$ is the layer-specific projection matrix.
+
+### Top-K Masking
+
+After delta optimization, a top-K mask is applied to keep only the most significant parameters:
+
+$$M = \mathbb{1}_{\{|\tau + \delta| \geq \text{kth\_value}\}}$$
+
+where K represents the percentage of top parameters to retain (e.g., K=30 keeps the top 30% by magnitude).
+
+### Final Merging
+
+The final merged model is:
+
+$$\theta = \theta_0 + \sum_i \lambda_i (\tau_i + \delta) \odot M$$
+
+where $\odot$ denotes element-wise multiplication with the mask.
+
+## Configuration
+
+```yaml title="config/method/doge_ta/doge_ta.yaml"
+--8<-- "config/method/doge_ta/doge_ta.yaml"
+```
+
+Key configuration parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `subspace` | Number of singular vectors for the shared subspace | `6` |
+| `K` | Top-K percentage for parameter masking (e.g., 30 for top 30%) | `30` |
+| `lamda` | Scaling factor for lambda computation | `0.07` |
+
+## Examples
+
+### CLI Usage
+
+Run DogeTA on CLIP models:
+
+```bash
+fusion_bench \
+    method=doge_ta/doge_ta \
+    method.subspace=6 \
+    method.K=30 \
+    method.lamda=0.07 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8_model_only \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.doge_ta.doge_ta import DOGE_TA_Algorithm
+
+algorithm = DOGE_TA_Algorithm(subspace=6, K=30, lamda=0.07)
+
+# modelpool must contain '_pretrained_' and fine-tuned models
+merged_model = algorithm.run(modelpool)
+```
+
+## Related: Layer-Wise AdaMerging with DogeTA
+
+The `layer_wise_adamerging.py` file provides an alternative DogeTA-based approach using the AdaMerging framework. The `LayerWiseAdaMergingAlgorithm` class constructs a `LayerWiseMergedModel` and performs test-time adaptation to learn layer-wise merging weights via entropy minimization. When used with DogeTA configs, it provides a data-driven alternative to the projection-based DogeTA approach.
+
+### Configuration
+
+The layer-wise AdaMerging variant can be invoked via:
+
+```bash
+fusion_bench \
+    method=adamerging/clip \
+    method.name=clip_layer_wise_adamerging_doge_ta \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+## Implementation Details
+
+- **State dict filtering**: Only parameters matching `"encoder" in key and "layer_norm" not in key and "weight" in key` are used for task vector computation.
+- **Delta initialization**: Delta is initialized as zeros matching the shape of task vectors.
+- **Optimization**: Adam optimizer with learning rate 1e-4, 400 steps per layer.
+- **Memory management**: The implementation explicitly tracks and reports memory usage, freeing the projection matrices and moving tensors to CPU after optimization.
+- **Vector-state dict conversion**: Helper methods `state_dict_to_vector` and `vector_to_state_dict` handle the flattening and unflattening of parameters for top-K masking.
+
+## References
+
+[^1]: (arXiv 2025) Modeling Multi-Task Model Merging as Adaptive Projective Gradient Descent. http://arxiv.org/abs/2501.01230

--- a/docs/algorithms/dop.md
+++ b/docs/algorithms/dop.md
@@ -1,0 +1,179 @@
+# DoP (Dual Projections)
+
+DoP (Dual Projections for Balancing Stability and Plasticity) is a continual model merging algorithm that operates without access to training data. It sequentially merges fine-tuned models into a single model, using Singular Value Decomposition (SVD) to define projection subspaces for each task vector. By projecting weight differences onto these subspaces, DoP balances **stability** (preserving knowledge from previously merged models) and **plasticity** (incorporating knowledge from new models).
+
+## Algorithm Overview
+
+### Continual Merging Setting
+
+DoP addresses the continual model merging scenario where models arrive sequentially and must be merged without storing all models in memory simultaneously. The algorithm processes models one at a time:
+
+1. The first model is used as the initial merged model.
+2. Each subsequent model is merged with the current merged result using layer-wise optimization.
+3. The output after processing all models is the final merged model.
+
+### SVD-Based Projection
+
+For each fine-tuned model, DoP computes the task vector $\tau = \theta_{\text{fine-tuned}} - \theta_{\text{pretrained}}$ and performs SVD:
+
+$$\tau = U S V^T$$
+
+Only the top singular components (those capturing `svd_epsilon` fraction of the total energy) are retained, defining a low-rank projection subspace. This captures the "direction" in parameter space where the model was fine-tuned.
+
+### Dual Projection Loss
+
+For each layer, DoP defines a loss function that measures the distance between the merged weight and each fine-tuned weight in the SVD subspace. The "dual" refers to projecting onto both the left singular vectors (U) and right singular vectors (V):
+
+$$\mathcal{L}_i^{(U)} = \| S^{1/2} U_{\text{main}}^T (\theta_{\text{merged}} - \theta_i) \|_F^2$$
+
+$$\mathcal{L}_i^{(V)} = \| (\theta_{\text{merged}} - \theta_i) V_{\text{main}} S^{1/2} \|_F^2$$
+
+The combined loss is:
+
+$$\mathcal{L}_i = \mathcal{L}_i^{(U)} + \mathcal{L}_i^{(V)}$$
+
+### Loss Balancing
+
+Two strategies are available for balancing the losses from the merged model (stability) and the new model (plasticity):
+
+1. **MGDA (Multi-Gradient Descent Algorithm)**: Uses Frank-Wolfe iteration to find optimal loss weights that minimize the norm of the combined gradient. With EMA (exponential moving average), the weights are smoothed over time.
+2. **Fixed alpha**: Uses a fixed weight $\alpha$ for the merged model and $(1-\alpha)$ for the new model.
+
+## Mathematical Formulation
+
+### SVD Rank Selection
+
+Given singular values $s_1 \geq s_2 \geq ... \geq s_r$, the rank $k$ is selected such that:
+
+$$\frac{\sum_{j=1}^{k} s_j}{\sum_{j=1}^{r} s_j} \geq \epsilon$$
+
+where $\epsilon$ is `svd_epsilon` (default 0.99999). Only the top $k$ singular triplets $(u_j, s_j, v_j)$ are kept.
+
+### Projection Loss Computation
+
+```python
+def cal_loss_i(delta_tv, proj_s, proj_u, proj_v):
+    proj_delta_1 = diag(S) @ U^T @ delta    # Left projection
+    proj_delta_2 = delta @ V @ diag(S)       # Right projection
+    loss_U = ||proj_delta_1||_F^2
+    loss_V = ||proj_delta_2||_F^2
+    return loss_U + loss_V    # or just one of them
+```
+
+### MGDA Optimization
+
+When MGDA is enabled, the algorithm:
+
+1. Computes gradients $\nabla \mathcal{L}_0$ and $\nabla \mathcal{L}_1$ for the merged and new model losses.
+2. Normalizes gradients by loss values.
+3. Finds the minimum-norm element in the convex hull of gradients (Frank-Wolfe).
+4. Applies EMA smoothing: $\alpha_t = \beta \alpha_{t-1} + (1-\beta) \alpha_{\text{FW}}$.
+5. Computes the combined loss: $\mathcal{L} = \alpha_t \mathcal{L}_0 + (1-\alpha_t) \mathcal{L}_1$.
+
+### Projection Space Options
+
+The `svd_proj_space` parameter controls which projection is used:
+
+- **`uv`** (default): Both left and right projections.
+- **`u`**: Only left projection (row space).
+- **`v`**: Only right projection (column space).
+
+## Configuration
+
+### CLIP-Specific DOP
+
+```yaml title="config/method/dop/dop.yaml"
+--8<-- "config/method/dop/dop.yaml"
+```
+
+### General DOP (Architecture-Agnostic)
+
+```yaml title="config/method/dop/dop_general.yaml"
+--8<-- "config/method/dop/dop_general.yaml"
+```
+
+Key configuration parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `lr` | Learning rate for weight optimization | `1e-4` |
+| `num_steps` | Optimization steps per layer | `200` |
+| `mgda` | Use MGDA for loss balancing | `true` |
+| `ema` | Apply EMA to MGDA weights | `true` |
+| `ema_beta` | EMA decay rate | `0.999` |
+| `alpha` | Fixed weight (if mgda=false) or initial weight (if mgda+ema) | `0.8` |
+| `svd_epsilon` | Fraction of energy to retain in SVD | `0.99999` |
+| `svd_proj_space` | Projection space: `u`, `v`, or `uv` | `uv` |
+| `shuffle_order` | Shuffle model order before merging | `true` |
+| `num_ray_actors` | Parallel Ray actors (0 = disabled) | `0` |
+
+## Examples
+
+### CLI Usage
+
+Run DOP on CLIP models:
+
+```bash
+fusion_bench \
+    method=dop/dop \
+    method.shuffle_order=true \
+    method.mgda=true \
+    method.svd_epsilon=0.99999 \
+    method.svd_proj_space=uv \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8_model_only \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Run the general DOP with fixed alpha (no MGDA):
+
+```bash
+fusion_bench \
+    method=dop/dop_general \
+    method.mgda=false \
+    method.alpha=0.7 \
+    method.num_steps=300 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8_model_only \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.dop.dop_general import DOPMerging
+from fusion_bench.modelpool import BaseModelPool
+
+algorithm = DOPMerging(
+    lr=1e-4,
+    num_steps=200,
+    mgda=True,
+    ema=True,
+    svd_epsilon=0.99999,
+    svd_proj_space="uv",
+)
+
+merged_model = algorithm.run(modelpool)
+```
+
+## Implementation Details
+
+### Two Implementations
+
+1. **`ContinualDOPForCLIP`** (`dop.py`): CLIP-specific implementation with explicit support for CLIPVisionModel and CLIPVisionModelTaskPool. Includes options for saving intermediate models and step-wise evaluation.
+
+2. **`DOPMerging`** (`dop_general.py`): Architecture-agnostic implementation that works with any model pool. Includes support for Ray-based parallel processing via `num_ray_actors`, dtype handling for SVD compatibility, and profiling.
+
+### Layer-wise Optimization
+
+Both implementations iterate through all leaf modules in the pretrained model. For `nn.Linear` layers with trainable weights (not in `exclude_keys`), they perform gradient-based optimization. For other layers (e.g., layer norms, embeddings), simple averaging is applied. Biases are always averaged.
+
+### Memory Management
+
+The algorithm processes one model at a time and deletes the fine-tuned model after merging (`del finetuned_model`), reducing memory pressure during continual merging.
+
+### Ray Parallelism
+
+The general implementation supports distributing layer-wise optimization across Ray actors. Each actor independently optimizes a linear layer's weights, enabling parallel processing of multiple layers.
+
+## References
+
+[^1]: (NeurIPS 2025) Continual Model Merging without Data: Dual Projections for Balancing Stability and Plasticity. http://arxiv.org/abs/2406.12345

--- a/docs/algorithms/expert_sparsity.md
+++ b/docs/algorithms/expert_sparsity.md
@@ -1,0 +1,126 @@
+# Expert Sparsity
+
+Expert Sparsity provides a suite of methods for pruning and optimizing Mixture-of-Experts (MoE) language models, specifically targeting Mixtral architectures. The goal is to reduce the number of experts or the computation per token while maintaining model quality, enabling faster inference and lower memory usage.
+
+The implementation follows the paper "Not All Experts are Equal: Efficient Expert Pruning and Skipping for Mixture-of-Experts Large Language Models" (ACL 2024), which presents three complementary techniques: Layer-Wise Pruning, Progressive Pruning, and Dynamic Skipping.
+
+## Layer-Wise Pruning
+
+Layer-wise pruning selects a subset of experts for each layer independently. The algorithm works as follows:
+
+1. **Wrapper Insertion**: Each `MixtralSparseMoeBlock` is wrapped in a `PrunableMixtralSparseMoeBlockWrapper` that caches input activations ($X$) and intermediate outputs ($Z$).
+
+2. **Calibration Forward Pass**: Calibration data is forwarded through the model to accumulate activation statistics.
+
+3. **Expert Enumeration**: For each layer, the wrapper evaluates all possible combinations of preserving $r$ experts out of the total, computing the reconstruction loss (difference between the original MoE output and the pruned output) for each combination.
+
+4. **Optimal Selection**: The combination with the lowest reconstruction loss is selected, and the pruned MoE block retains only those experts.
+
+$$\text{loss}(S) = \frac{1}{|D|} \sum_{x \in D} \| \text{MoE}_{\text{full}}(x) - \text{MoE}_{\text{pruned}, S}(x) \|_2^2$$
+
+where $S$ is a subset of $r$ experts.
+
+### CLI Usage
+
+```yaml title="config/method/expert_sparsity/mixtral.yaml"
+--8<-- "config/method/expert_sparsity/mixtral.yaml"
+```
+
+```bash
+fusion_bench \
+  method=expert_sparsity/mixtral \
+  method._target_=fusion_bench.method.LayerWisePruningForMixtral \
+  method.num_preserved_experts=4 \
+  method.calib_set=c4 \
+  method.n_blocks_for_stat=128 \
+  method.batch_size=8 \
+  modelpool=CausalLMPool/mixtral-8x7b
+```
+
+## Progressive Pruning
+
+Progressive pruning is a memory-efficient variant that prunes one layer at a time, replacing the wrapper with the pruned model before moving to the next layer. This reduces peak memory usage:
+
+1. **Z-activation Collection**: First pass collects only the intermediate expert outputs ($Z$) for all layers.
+
+2. **Layer-by-Layer X-Collection**: For each layer, a forward pass collects the input activations ($X$) for that layer only. After enumerating and pruning, the wrapper is replaced with the pruned model, freeing memory.
+
+3. **Result**: The same optimal subset selection as layer-wise pruning, but with lower memory overhead.
+
+### CLI Usage
+
+```bash
+fusion_bench \
+  method=expert_sparsity/mixtral \
+  method._target_=fusion_bench.method.ProgressivePruningForMixtral \
+  method.num_preserved_experts=4 \
+  method.calib_set=c4 \
+  method.n_blocks_for_stat=128 \
+  method.batch_size=8 \
+  modelpool=CausalLMPool/mixtral-8x7b
+```
+
+## Dynamic Skipping
+
+Dynamic skipping is a runtime optimization that analyzes the routing weight ratios across calibration data to determine per-layer beta parameters. These betas control how aggressively tokens can skip the second-ranked expert during inference:
+
+1. **Router Logit Collection**: The wrapper caches router logits, input activations ($X$), and expert outputs ($Z$).
+
+2. **Ratio Analysis**: For each token, the ratio of the second-highest routing weight to the highest is computed:
+
+$$\rho = \frac{w_{(2)}}{w_{(1)}}$$
+
+where $w_{(1)}$ and $w_{(2)}$ are the sorted routing weights (descending).
+
+3. **Beta Computation**: The median (and mean) of $\rho$ across all tokens and positions is computed per layer. The median is stored as `model.config.betas[layer_idx]` and used at inference time to decide whether the second expert can be skipped.
+
+### CLI Usage
+
+```bash
+fusion_bench \
+  method=expert_sparsity/mixtral \
+  method._target_=fusion_bench.method.DynamicSkippingPruningForMixtral \
+  method.calib_set=c4 \
+  method.n_blocks_for_stat=128 \
+  method.batch_size=8 \
+  modelpool=CausalLMPool/mixtral-8x7b
+```
+
+## Calibration Data
+
+All three methods use calibration data for analysis. Supported datasets:
+
+- **C4**: The Common Crawl C4 corpus (English subset). Downloaded from `allenai/c4` on HuggingFace Hub.
+- **MATH**: A math pretraining-style dataset from `tanganke/math_pretrain_style`.
+
+### Common Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_preserved_experts` | int | 4 | Number of experts to keep per layer (pruning methods). |
+| `calib_set` | str | "c4" | Calibration dataset: "c4" or "math". |
+| `max_block_size` | int | 2048 | Max sequence length per calibration sample. |
+| `n_blocks_for_stat` | int | 128 | Number of sequence blocks for calibration. 0 = use entire dataset. |
+| `batch_size` | int | 8 | Batch size for calibration forward passes. |
+| `num_workers` | int | 8 | DataLoader workers. |
+| `seed` | int | 42 | Random seed for calibration data shuffling. |
+| `model_save_path` | str | "{log_dir}/pruned_model" | Path to save the pruned model. |
+
+## Output
+
+- **Pruning methods**: Return the pruned `MixtralForCausalLM` model with `num_experts` reduced to `num_preserved_experts`. Also save pruning info (loss history per layer) to `{log_dir}/pruning_info.pt`.
+
+- **Dynamic Skipping**: Return the original model with `config.betas` set to the per-layer median routing ratios. Also save `(res_median, res_mean)` to `{log_dir}/pruning_info.pt`.
+
+## Implementation Details
+
+- [fusion_bench.method.expert_sparsity.mixtral.layer_wise_pruning.LayerWisePruningForMixtral][]
+- [fusion_bench.method.expert_sparsity.mixtral.layer_wise_pruning.layerwise_pruning][]
+- [fusion_bench.method.expert_sparsity.mixtral.progressive_pruning.ProgressivePruningForMixtral][]
+- [fusion_bench.method.expert_sparsity.mixtral.progressive_pruning.progressive_pruning][]
+- [fusion_bench.method.expert_sparsity.mixtral.dynamic_skipping.DynamicSkippingPruningForMixtral][]
+- [fusion_bench.method.expert_sparsity.mixtral.dynamic_skipping.dynamic_skipping][]
+- [fusion_bench.method.expert_sparsity.utils.calibration_data.build_calib_loader][]
+
+[^1]: (ACL 2024) Not All Experts are Equal: Efficient Expert Pruning and Skipping for Mixture-of-Experts Large Language Models. http://arxiv.org/abs/2402.14800
+[^2]: Original repo: https://github.com/Lucky-Lance/Expert_Sparsity

--- a/docs/algorithms/fw_merging.md
+++ b/docs/algorithms/fw_merging.md
@@ -1,0 +1,210 @@
+# Fisher Whitelister (FW Merging)
+
+Fisher Whitelister is an iterative model merging algorithm based on the Frank-Wolfe (conditional gradient) optimization framework. At each iteration, it selects the fine-tuned model whose parameters most strongly align with the current gradient of the loss, then merges it into the running model. This greedy selection strategy effectively builds a "whitelist" of the most useful models for the merging objective.
+
+The algorithm comes in two variants: **Hard** and **Soft**, each with different merging strategies and optimization approaches.
+
+## Algorithm Overview
+
+### The Frank-Wolfe Framework
+
+The Frank-Wolfe algorithm solves constrained optimization problems by iteratively:
+
+1. Computing the gradient of the objective at the current solution.
+2. Finding the extreme point (in this case, a model checkpoint) that most minimizes the linear approximation of the objective.
+3. Moving toward that point with a decaying step size.
+
+In model merging, the "extreme points" are the fine-tuned model parameters, and the "gradient" is computed from the loss on the target tasks.
+
+### Model Selection Criterion
+
+At each iteration, the algorithm computes the gradient of a loss function (cross-entropy or entropy) w.r.t. the merged model's parameters. It then selects the fine-tuned model whose state dictionary has the minimum inner product (maximum negative alignment) with the gradient:
+
+$$\text{score}(m) = \sum_{p} \frac{\nabla_p \mathcal{L} \cdot \theta_{m,p}}{\|\nabla_p \mathcal{L}\| \cdot \|\theta_{m,p}\|}$$
+
+The model minimizing this cosine similarity sum is selected, as it points most directly downhill in the loss landscape.
+
+### Granularity
+
+Two granularity levels are supported:
+
+- **`task`** (default): Select one model per iteration for the entire model.
+- **`layer`**: Select the best model per parameter/layer independently, constructing a composite model from different sources.
+
+## Hard Variant (FrankWolfeHardAlgorithm)
+
+### Merging Functions
+
+The Hard variant supports two merging backbones:
+
+1. **Task Arithmetic**: Merges using task vectors scaled by the Frank-Wolfe step size.
+2. **TIES Merging**: Applies TIES (Trimmed, Eliminated, and Signed) merging with configurable threshold for conflict resolution.
+
+### Iteration Process
+
+1. Compute loss gradients over `dataset_size` samples from each task.
+2. Select the model with minimum gradient alignment.
+3. Determine step size: $\gamma_t = \frac{2}{t+2} \cdot \text{step\_size}$.
+4. Merge the selected model into the current merged model using the chosen merge function.
+
+### Initialization
+
+The merged model can be initialized in three ways:
+
+- **`base`**: Start from the pretrained model.
+- **Empty string (`""`)**: Start from a merge of all models using the merge function.
+- **File path**: Load layer-wise weights from a saved tensor file.
+
+## Soft Variant (FrankWolfeSoftAlgorithm)
+
+### Key Differences
+
+The Soft variant extends the Hard variant with:
+
+1. **AdaMerging integration**: Instead of a static merge, the Soft variant can use AdaMerging to learn optimal merging weights via test-time adaptation after each Frank-Wolfe iteration.
+2. **Per-task model selection**: Models are selected independently for each task within an iteration, then all selected models are merged together.
+3. **AdaMerging as merge function**: When `merge_fn="adamerging"`, the selected models are combined using layer-wise AdaMerging with entropy minimization.
+
+### Iteration Process (Soft with AdaMerging)
+
+1. For each task, compute gradients and select the best-aligned model.
+2. Construct a `LayerWiseMergedModel` with all selected models.
+3. Run AdaMerging for `ada_iters` steps to optimize layer-wise weights.
+4. The result becomes the new merged model.
+
+### Projection onto Simplex
+
+The Soft variant includes a `projection_simplex_sort` utility that projects a vector onto the probability simplex, ensuring non-negative weights that sum to one. This is used in the AdaMerging weight optimization.
+
+## Mathematical Formulation
+
+### Gradient Computation
+
+For each task $t$, the gradient is computed over `dataset_size` samples:
+
+$$\nabla \mathcal{L} = \frac{1}{D \cdot T} \sum_{d=1}^{D} \nabla_\theta \ell(f_\theta(x_d), y_d)$$
+
+where $D$ is `dataset_size` and $T$ is the number of tasks.
+
+### Frank-Wolfe Step Size
+
+The step size follows the standard Frank-Wolfe schedule:
+
+$$\gamma_t = \frac{2}{t + 2} \cdot \alpha$$
+
+where $\alpha$ is the `step_size` hyperparameter and $t$ is the iteration index.
+
+### Task Arithmetic Merge
+
+$$\theta_{t+1} = \theta_t + \gamma_t \cdot (\theta_{\text{selected}} - \theta_{\text{pretrained}})$$
+
+### TIES Merge
+
+TIES merging applies sign-based conflict resolution and magnitude thresholding before summing task vectors.
+
+### AdaMerging (Soft variant)
+
+For each layer $l$, learn weights $w^{(l)}$ by:
+
+$$\min_{w^{(l)}} \mathcal{L}_{\text{entropy}}\left( \sum_j w^{(l)}_j \cdot (\theta_j^{(l)} - \theta_0^{(l)}) + \theta_0^{(l)} \right)$$
+
+subject to $w^{(l)} \in [0, 1]$ and $\sum_j w^{(l)}_j = 1$ (if `tie_weights` is enabled).
+
+## Configuration
+
+### Hard Variant
+
+```yaml title="config/method/fw_merging/fw_hard.yaml"
+--8<-- "config/method/fw_merging/fw_hard.yaml"
+```
+
+### Soft Variant
+
+```yaml title="config/method/fw_merging/fw_soft.yaml"
+--8<-- "config/method/fw_merging/fw_soft.yaml"
+```
+
+Key configuration parameters:
+
+| Parameter | Description | Hard Default | Soft Default |
+|-----------|-------------|-------------|-------------|
+| `merge_fn` | Merge function: `task_arithmetic`, `ties`, or `adamerging` | `task_arithmetic` | `adamerging` |
+| `max_iters` | Number of Frank-Wolfe iterations | `10` | `10` |
+| `step_size` | Frank-Wolfe step size multiplier | `0.1` | `0.1` |
+| `dataset_size` | Samples per task for gradient computation | `100` | `100` |
+| `granularity` | Selection granularity: `task` or `layer` | `task` | `task` |
+| `init_weight` | Initialization: `base`, file path, or empty | `""` | `""` |
+| `ada_iters` | AdaMerging iterations (Soft only) | N/A | `500` |
+| `ada_coeff` | AdaMerging initial weight coefficient | N/A | `1e-8` |
+| `ada_loss` | AdaMerging loss: `entropy_loss` or `cross_entropy` | N/A | `entropy_loss` |
+
+## Examples
+
+### CLI Usage
+
+Hard variant with Task Arithmetic:
+
+```bash
+fusion_bench \
+    method=fw_merging/fw_hard \
+    method.merge_fn=task_arithmetic \
+    method.max_iters=10 \
+    method.step_size=0.1 \
+    method.granularity=task \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Hard variant with TIES merging:
+
+```bash
+fusion_bench \
+    method=fw_merging/fw_hard \
+    method.merge_fn=ties \
+    method.threshold=20 \
+    method.scaling_factor=0.3 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Soft variant with AdaMerging:
+
+```bash
+fusion_bench \
+    method=fw_merging/fw_soft \
+    method.merge_fn=adamerging \
+    method.ada_iters=500 \
+    method.max_iters=10 \
+    method.granularity=task \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.fw_merging.fw_hard import FrankWolfeHardAlgorithm
+
+algorithm = FrankWolfeHardAlgorithm(
+    merge_fn="task_arithmetic",
+    step_size=0.1,
+    max_iters=10,
+    dataset_size=100,
+    granularity="task",
+)
+
+merged_model = algorithm.run(modelpool)
+```
+
+## Implementation Details
+
+- **Gradient computation**: The `frank_wolfe_iteration` method computes gradients over a subset of training data. The loss is normalized by `dataset_size * number_of_tasks`.
+- **Model selection**: The `frank_wolfe_selection` method computes cosine similarity between gradients and model parameters for each candidate model.
+- **State preservation**: The `set_requires_grad` method in the Soft variant preserves the original pretrained model's gradient requirements on the merged model.
+- **Loss functions**: Both variants support cross-entropy (using labels) and entropy (label-free) loss functions. The Soft variant's AdaMerging uses the `ada_loss` parameter to switch between them.
+
+## References
+
+[^1]: Frank-Wolfe algorithm for conditional gradient optimization. Provides the theoretical foundation for iterative model selection and merging.
+[^2]: (ICLR 2023) Editing Models with Task Arithmetic. http://arxiv.org/abs/2212.04089
+[^3]: (ICLR 2023) TIES-Merging: Resolving Interference in Model Parameter Upstream. http://arxiv.org/abs/2303.09922

--- a/docs/algorithms/gossip.md
+++ b/docs/algorithms/gossip.md
@@ -1,0 +1,143 @@
+# Gossip
+
+Gossip merging is a decentralized model fusion strategy that simulates distributed model merging through iterative pairwise communication. Instead of performing a single global merge, models exchange knowledge with their neighbors over multiple rounds, each round performing local adaptive merging. This approach better simulates real-world scenarios where models are distributed across different nodes and cannot access a central model pool simultaneously.
+
+The Gossip algorithm builds upon the AdaMerging framework, combining two key ideas:
+
+1. **Layer-wise or task-wise adaptive merging**: Learn optimal merging weights via test-time adaptation using entropy minimization.
+2. **Gossip communication topology**: Models communicate with neighbors in a ring or rotated topology, propagating knowledge incrementally across rounds.
+
+## Algorithm Overview
+
+### Model Scheduler
+
+The `ModelScheduler` class manages model storage and determines which models participate in each gossip round. For each model `i` in a round, the scheduler constructs a local merging environment based on the topology:
+
+- **Ring topology (`ring`)**: Model `i` merges with its left and right neighbors, i.e., models `(i-1) % N`, `i`, and `(i+1) % N`.
+- **Rotate topology (`rotate_K`)**: Model `i` merges with itself and the next `K` models in cyclic order: models `i`, `(i+1) % N`, ..., `(i+K) % N`.
+
+### Gossip Merging Process
+
+The algorithm proceeds in `gossip_max_steps` rounds. In each round:
+
+1. For each model `i` from `0` to `N-1`:
+   - The scheduler selects the neighbor models according to the topology.
+   - A `LayerWiseMergedModel` (or `TaskWiseMergedModel`) is constructed with the pretrained model and the selected fine-tuned models.
+   - Test-time adaptation optimizes the layer-wise (or task-wise) merging weights via entropy minimization.
+   - The resulting merged weights are stored back as the updated fine-tuned model `i`.
+2. After all models have been processed, the scheduler updates the model pool with the new models.
+
+The process iterates, allowing knowledge to propagate through the network. The `improve_dataset` flag controls whether each local merge only uses data from tasks involved in that local merge.
+
+## Mathematical Formulation
+
+### Layer-Wise Merging Weights
+
+For layer-wise gossip, let $W^{(i)} \in \mathbb{R}^{L \times M_i}$ denote the layer-wise merging weight matrix for model $i$, where $L$ is the number of layers and $M_i$ is the number of models involved in model $i$'s local merge. The merged parameter for layer $l$ is computed as:
+
+$$\theta_{\text{merged}}^{(l)} = \sum_{j=1}^{M_i} W^{(i)}_{l,j} \cdot (\theta_j^{(l)} - \theta_0^{(l)}) + \theta_0^{(l)}$$
+
+where $\theta_j^{(l)}$ is the parameter of fine-tuned model $j$ at layer $l$, and $\theta_0^{(l)}$ is the pretrained parameter.
+
+### Task-Wise Merging Weights
+
+For task-wise gossip, a single scalar weight per model is learned:
+
+$$\theta_{\text{merged}} = \sum_{j=1}^{M_i} W^{(i)}_j \cdot (\theta_j - \theta_0) + \theta_0$$
+
+### Entropy Minimization
+
+The merging weights are optimized by minimizing the entropy of the model's predictions on a small calibration set:
+
+$$\mathcal{L}_{\text{entropy}} = -\mathbb{E}_{x \sim \mathcal{D}} \left[ \sum_{c} p(c|x) \log p(c|x) \right]$$
+
+where $p(c|x) = \text{softmax}(z_c(x))$ is the softmax probability distribution over classes, and $z_c(x)$ denotes the logit for class $c$ on input $x$. The gradient of this loss flows through the merging weights, enabling differentiable optimization of the merge.
+
+### Weight Constraints
+
+The merging weights can be optionally constrained:
+
+$$W \in [0, 1] \quad \text{(if `clamp_weights` is enabled)}$$
+
+$$\sum_{j} W_j = 1 \quad \text{(if `tie_weights` is enabled)}$$
+
+## Variants
+
+### CLIPLayerWiseGossipAlgorithm
+
+The CLIP-specific variant (`clip_layer_wise_gossip.py`) extends `LayerWiseGossipAlgorithm` with CLIP zero-shot classification capabilities. It sets up a zero-shot classification head using the CLIP text encoder and computes logits via the CLIP vision model's pooled output.
+
+### FlanT5LayerWiseGossipAlgorithm
+
+The Flan-T5 variant (`flan_t5_layer_wise_gossip.py`) adapts the gossip algorithm for the Flan-T5 language model, using sequence classification heads for test-time adaptation.
+
+### TaskWiseGossipAlgorithm
+
+The task-wise variant (`task_wise_gossip.py`) performs merging at the model level rather than the layer level. Each local merge learns a single scalar weight per model, controlling how much of each model's task vector contributes to the merged result.
+
+## Configuration
+
+### Layer-Wise CLIP Gossip
+
+```yaml title="config/method/gossip/layer_wise_clip.yaml"
+--8<-- "config/method/gossip/layer_wise_clip.yaml"
+```
+
+### Layer-Wise Flan-T5 Gossip
+
+```yaml title="config/method/gossip/layer_wise_flan_t5.yaml"
+--8<-- "config/method/gossip/layer_wise_flan_t5.yaml"
+```
+
+## Examples
+
+### CLI Usage
+
+Run layer-wise gossip merging on CLIP models:
+
+```bash
+fusion_bench \
+    method=gossip/layer_wise_clip \
+    method.gossip_max_steps=20 \
+    method.max_steps=400 \
+    method.topo=ring \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Run gossip merging with rotate topology (each model communicates with 2 neighbors):
+
+```bash
+fusion_bench \
+    method=gossip/layer_wise_clip \
+    method.topo=rotate_2 \
+    method.gossip_max_steps=15 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Skip the AdaMerging step (only perform static merging with gossip):
+
+```bash
+fusion_bench \
+    method=gossip/layer_wise_clip \
+    method.gossip_skip_adamerging=true \
+    method.gossip_max_steps=10 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+## Implementation Details
+
+The implementation uses several key components:
+
+- **ModelScheduler** (`ModelScheduler` class): Manages model loading, neighbor selection, and storage of updated models. The `update_datasets` method adjusts which datasets are used for each local merge when `improve_dataset` is enabled.
+- **LayerWiseMergedModel**: A wrapper model that performs differentiable layer-wise interpolation between the pretrained and fine-tuned models.
+- **TaskWiseMergedModel**: A wrapper model that performs differentiable task-wise interpolation at the model level.
+- **Entropy loss**: The optimization objective for test-time adaptation, encouraging the merged model to make confident predictions.
+- **Memory management**: The `free_gpu_memory` method explicitly moves models to CPU and clears GPU cache between merges to simulate distributed memory constraints.
+
+## References
+
+[^1]: (NeurIPS 2023) Communication-Efficient On-Device Machine Learning: Federated Learning and Beyond. Discusses gossip-based distributed optimization for model aggregation.
+[^2]: (ICLR 2024) AdaMerging: Adaptive Model Merging for Multi-Task Learning. http://arxiv.org/abs/2310.02575. The base adaptive merging algorithm extended by the gossip framework.

--- a/docs/algorithms/layer_recombination.md
+++ b/docs/algorithms/layer_recombination.md
@@ -1,2 +1,0 @@
-# Layer Recombination
-

--- a/docs/algorithms/linear.md
+++ b/docs/algorithms/linear.md
@@ -1,0 +1,226 @@
+# Linear Model Merging Methods
+
+Linear model merging encompasses a family of methods that combine model parameters through linear operations -- interpolation, extrapolation, and weighted averaging. These methods form the foundation of model fusion, with more advanced techniques often building upon them.
+
+## Overview
+
+Linear merging methods operate by computing a linear combination of model parameters. Given models with parameters $\theta_1, \theta_2, \dots, \theta_K$, the merged model is:
+
+$$\theta_{merged} = \sum_{i=1}^{K} w_i \theta_i$$
+
+where $\sum_i w_i = 1$ and $w_i$ are the merging weights. The specific choice of weights and the relationship between the models define the variant.
+
+FusionBench implements several linear merging methods:
+
+1. **Linear Interpolation**: Interpolates between two models with a parameter $t \in [0, 1]$.
+2. **ExPO (Extrapolation)**: Extrapolates from a pretrained model through a fine-tuned model.
+3. **ExPO for LLaMA**: A LLaMA-specific variant of ExPO with layer-wise control.
+4. **Simple Average for Causal LM**: Uniform averaging with optional backbone-only merging.
+
+## Linear Interpolation
+
+The simplest linear merge method interpolates between two models:
+
+$$\theta = (1 - t) \theta_1 + t \theta_2$$
+
+where $t \in [0, 1]$ controls the interpolation: $t = 0$ yields $\theta_1$, $t = 1$ yields $\theta_2$, and $t = 0.5$ gives the simple average.
+
+```python
+from fusion_bench.method import LinearInterpolationAlgorithm
+
+algorithm = LinearInterpolationAlgorithm(t=0.5)
+merged_model = algorithm.run(modelpool)  # modelpool must have exactly 2 models
+```
+
+### Configuration
+
+```yaml title="config/method/linear/linear_interpolation.yaml"
+--8<-- "config/method/linear/linear_interpolation.yaml"
+```
+
+### CLI Usage
+
+```bash
+fusion_bench method=linear/linear_interpolation \
+    method.t=0.5 \
+    modelpool=CausalLMPool/two_models \
+    taskpool=...
+```
+
+## ExPO (Extrapolation)
+
+ExPO (Extrapolation from Pretrained to Optimized) extends the idea of linear interpolation into extrapolation. Given a pretrained (SFT) model $\theta_{pre}$ and a fine-tuned (RLHF) model $\theta_{ft}$, ExPO computes:
+
+$$\theta_{merged} = \theta_{ft} + \alpha (\theta_{ft} - \theta_{pre})$$
+
+where $\alpha$ is the extrapolation factor. When $\alpha > 0$, the merged model lies on the ray from $\theta_{pre}$ through $\theta_{ft}$, beyond $\theta_{ft}$. This can amplify the alignment improvements introduced by fine-tuning[^2].
+
+### General ExPO
+
+For general `nn.Module` models, the `ExPOAlgorithm` class handles any model architecture:
+
+```python
+from fusion_bench.method import ExPOAlgorithm
+
+algorithm = ExPOAlgorithm(extrapolation_factor=0.1)
+merged_model = algorithm.run(modelpool)
+```
+
+When multiple RLHF models are provided, ExPO first averages them via `SimpleAverageAlgorithm`, then extrapolates from the pretrained model through the averaged RLHF model.
+
+### Configuration
+
+```yaml title="config/method/linear/expo.yaml"
+--8<-- "config/method/linear/expo.yaml"
+```
+
+### CLI Usage
+
+```bash
+fusion_bench method=linear/expo \
+    method.extrapolation_factor=0.1 \
+    modelpool=CausalLMPool/sft_and_rlhf \
+    taskpool=...
+```
+
+## ExPO for LLaMA
+
+The `ExPOAlgorithmForLlama` class provides fine-grained control over which parts of a LLaMA model are extrapolated. This is critical because different components (attention, MLP, embeddings, lm_head) may benefit from different treatment.
+
+### Key Parameters
+
+- **`extrapolation_factor`**: The extrapolation coefficient $\alpha$.
+- **`attention_scaling_factor`**: Scales the extrapolation factor for attention layers separately. The effective factor for attention becomes `extrapolation_factor * attention_scaling_factor`.
+- **`only_on_backbone`**: When `True`, only the backbone (transformer layers) is merged; the lm_head is kept from the RLHF model.
+- **`on_linear_weights`** / **`on_linear_bias`**: Control whether linear weights and biases are extrapolated.
+- **`on_embedding`**: Whether to extrapolate the token embedding layer.
+- **`fix_first_n_layers`** / **`fix_last_n_layers`**: Skip extrapolation for the first/last N layers (supports `"half"` for half the layers).
+- **`magnitude_sparsity_ratio`**: Optionally apply magnitude pruning to the delta vector before extrapolation.
+
+### Mathematical Formulation
+
+For each layer $l$, the LLaMA-specific ExPO applies:
+
+$$\theta^{(l)}_{merged} = \theta^{(l)}_{ft} + \alpha_l (\theta^{(l)}_{ft} - \theta^{(l)}_{pre})$$
+
+where $\alpha_l = \alpha \cdot \alpha_{attn}$ for attention layers and $\alpha_l = \alpha$ for MLP layers.
+
+If `magnitude_sparsity_ratio` is set, the delta $\delta = \theta_{ft} - \theta_{pre}$ is first pruned via unstructured magnitude pruning before scaling.
+
+### ExPO with DARE for LLaMA
+
+The `ExPOWithDareForLLama` variant first merges the RLHF models using DARE simple averaging (random drop and rescale), then applies ExPO extrapolation. This combines the benefits of DARE's interference reduction with ExPO's extrapolation:
+
+```python
+from fusion_bench.method import ExPOWithDareForLLama
+
+algorithm = ExPOWithDareForLLama(
+    extrapolation_factor=0.1,
+    dare_sparsity_ratio=0.5,
+    dare_only_on_linear_weights=True,
+    dare_rescale=True,
+)
+```
+
+### Configuration
+
+```yaml title="config/method/linear/llama_expo.yaml"
+--8<-- "config/method/linear/llama_expo.yaml"
+```
+
+### CLI Usage
+
+```bash
+fusion_bench method=linear/llama_expo \
+    method.extrapolation_factor=0.1 \
+    method.attention_scaling_factor=1.0 \
+    method.only_on_backbone=true \
+    modelpool=CausalLMPool/sft_and_rlhf \
+    taskpool=...
+```
+
+## Simple Average for Causal LM
+
+The `SimpleAverageForCausalLM` class extends the basic simple average with Causal LM-specific features:
+
+- **`merge_backbone`**: When `True`, only the backbone (transformer layers) is averaged. The lm_head is taken from the pretrained model. This is useful when merging models with different heads (e.g., chat vs. generation).
+- **`model_save_path`**: Save the merged model and tokenizer to the specified path.
+- **`show_pbar`**: Show a progress bar during merging.
+
+### Configuration
+
+```yaml title="config/method/linear/simple_average_for_causallm.yaml"
+--8<-- "config/method/linear/simple_average_for_causallm.yaml"
+```
+
+### CLI Usage
+
+```bash
+fusion_bench method=linear/simple_average_for_causallm \
+    method.merge_backbone=false \
+    method.model_save_path=outputs/merged_model \
+    method.show_pbar=true \
+    modelpool=CausalLMPool/multiple_models \
+    taskpool=...
+```
+
+### API Usage
+
+```python
+from fusion_bench.method import SimpleAverageForCausalLM
+
+algorithm = SimpleAverageForCausalLM(
+    merge_backbone=False,
+    model_save_path="outputs/merged",
+    show_pbar=True,
+)
+merged_model = algorithm.run(modelpool)
+```
+
+## Implementation Details
+
+### ExPO Merge Function
+
+The core `expo_merge()` function implements the extrapolation at the parameter level:
+
+```python
+def expo_merge(sft_model, rlhf_model, extrapolation_factor, inplace=True, enable_grad=False):
+    for (sft_name, sft_param), (rlhf_name, rlhf_param) in zip(
+        sft_model.named_parameters(), rlhf_model.named_parameters()
+    ):
+        rlhf_param.data = rlhf_param.data + extrapolation_factor * (
+            rlhf_param.data - sft_param.data
+        )
+    return rlhf_model
+```
+
+### Linear Interpolation
+
+The `LinearInterpolationAlgorithm` uses `state_dict_weighted_sum` to combine two state dictionaries:
+
+```python
+state_dict = state_dict_weighted_sum(
+    [primary_state_dict, secondary_state_dict], [1 - self.t, self.t]
+)
+```
+
+## Choosing a Method
+
+| Scenario | Recommended Method |
+|---|---|
+| Two models, equal importance | Linear Interpolation (t=0.5) or Simple Average |
+| Two models, unequal importance | Linear Interpolation with tuned $t$ |
+| Pretrained + aligned model | ExPO (general or LLaMA) |
+| Multiple RLHF models + SFT | ExPO (auto-averages RLHF models) |
+| Multiple RLHF + SFT, large models | ExPO with DARE for LLaMA |
+| Causal LMs with different heads | Simple Average for Causal LM (merge_backbone=True) |
+
+## Implementation Details
+
+- [ExPOAlgorithm][fusion_bench.method.ExPOAlgorithm]
+- [LinearInterpolationAlgorithm][fusion_bench.method.LinearInterpolationAlgorithm]
+- [ExPOAlgorithmForLlama][fusion_bench.method.ExPOAlgorithmForLlama]
+- [ExPOWithDareForLLama][fusion_bench.method.ExPOWithDareForLLama]
+- [SimpleAverageForCausalLM][fusion_bench.method.SimpleAverageForCausalLM]
+
+[^2]: (2024) Zheng et al. Weak-to-Strong Extrapolation Expedites Alignment. https://arxiv.org/abs/2404.12717

--- a/docs/algorithms/lm_finetune.md
+++ b/docs/algorithms/lm_finetune.md
@@ -1,0 +1,136 @@
+# LM Fine-tuning
+
+FusionBench provides three fine-tuning methods for language models: Full Fine-tuning for Supervised Fine-Tuning (SFT), PEFT (LoRA) Fine-tuning for SFT, and Bradley-Terry Reward Modeling. These methods use PyTorch Lightning Fabric for distributed training and support FSDP, gradient accumulation, and configurable checkpointing.
+
+## Full Fine-tuning SFT
+
+The `FullFinetuneSFT` algorithm performs full-parameter fine-tuning of a causal language model on supervised instruction datasets. All parameters of the model are updated (optionally excluding token embeddings via `fix_token_embedding`).
+
+**Training Loop**. For each batch, the model computes the autoregressive language modeling loss:
+
+$$\mathcal{L} = -\frac{1}{N} \sum_{i=1}^{N} \sum_{t} \log p(y_t | y_{<t}, x; \theta)$$
+
+where $N$ is the number of samples and the inner sum is over token positions. The loss is computed via the model's built-in cross-entropy (with labels shifted by one position).
+
+**Key Features**:
+- Supports gradient accumulation (`accumulate_grad_batches`).
+- Gradient clipping by value or norm (`gradient_clip_val`, `gradient_clip_algorithm`).
+- Configurable checkpointing (epoch or step interval, lightning or HuggingFace format).
+- FSDP-compatible with gradient checkpointing.
+- Optional token embedding freezing (`fix_token_embedding=true`).
+
+### CLI Usage
+
+```yaml title="config/method/lm_finetune/fullfinetune_sft.yaml"
+--8<-- "config/method/lm_finetune/fullfinetune_sft.yaml"
+```
+
+```bash
+fusion_bench \
+  method=lm_finetune/fullfinetune_sft \
+  method.optimizer.lr=1e-5 \
+  method.max_epochs=3 \
+  method.dataloader_kwargs.batch_size=1 \
+  method.max_length=4096 \
+  method.fix_token_embedding=true \
+  modelpool=CausalLMPool/meta-llama/Llama-2-7b-hf \
+  taskpool=dummy
+```
+
+## PEFT Fine-tuning SFT
+
+The `PeftFinetuneSFT` algorithm applies Parameter-Efficient Fine-Tuning (PEFT) using LoRA adapters. Only the LoRA parameters are updated, keeping the base model frozen.
+
+**LoRA Configuration**. LoRA low-rank adapters are applied to specified modules:
+
+$$W(x) = W_0 x + \frac{1}{\alpha} B A x$$
+
+where $W_0$ is the frozen original weight, $A \in \mathbb{R}^{r \times d_{\text{in}}}$ and $B \in \mathbb{R}^{d_{\text{out}} \times r}$ are the trainable low-rank matrices, $r$ is the LoRA rank, and $\alpha$ is the scaling factor (`lora_alpha`).
+
+**Key Features**:
+- Default targets: `q_proj`, `v_proj` (attention) and `gate_proj`, `down_proj`, `up_proj` (MLP).
+- LoRA rank `r=64`, `lora_alpha=16`, `lora_dropout=0` (configurable).
+- Post-training merge and unload option (`merge_and_unload=true`).
+- Supports both Lightning and PEFT checkpoint formats.
+
+### CLI Usage
+
+```yaml title="config/method/lm_finetune/peftfinetune_sft.yaml"
+--8<-- "config/method/lm_finetune/peftfinetune_sft.yaml"
+```
+
+```bash
+fusion_bench \
+  method=lm_finetune/peftfinetune_sft \
+  method.peft_config.r=64 \
+  method.peft_config.lora_alpha=16 \
+  method.optimizer.lr=1e-4 \
+  method.max_epochs=3 \
+  method.merge_and_unload=false \
+  modelpool=CausalLMPool/meta-llama/Llama-2-7b-hf \
+  taskpool=dummy
+```
+
+## Bradley-Terry Reward Modeling
+
+The `BradleyTerryRewardModeling` algorithm trains a reward model using the Bradley-Terry pairwise preference model. Given pairs of (chosen, rejected) responses, it learns to assign higher rewards to the chosen response.
+
+**The Bradley-Terry Loss**:
+
+$$\mathcal{L} = -\mathbb{E} \left[ \log \sigma(r_{\theta}(x, y_{\text{chosen}}) - r_{\theta}(x, y_{\text{rejected}})) \right]$$
+
+where $r_{\theta}$ is the reward model (a sequence classification head on top of the LLM), $\sigma$ is the sigmoid function, and $(x, y_{\text{chosen}})$ and $(x, y_{\text{rejected}})$ form a preference pair.
+
+**Dataset Format**. Each sample contains:
+- `chosen_input_ids`, `chosen_attention_mask`: Token IDs for the preferred response.
+- `rejected_input_ids`, `rejected_attention_mask`: Token IDs for the rejected response.
+
+The collate function stacks chosen and rejected samples in a single batch (batch size must be even).
+
+### CLI Usage
+
+```yaml title="config/method/lm_finetune/bradley_terry_rm.yaml"
+--8<-- "config/method/lm_finetune/bradley_terry_rm.yaml"
+```
+
+```bash
+fusion_bench \
+  method=lm_finetune/bradley_terry_rm \
+  method.optimizer.lr=1e-5 \
+  method.max_epochs=3 \
+  method.dataloader_kwargs.batch_size=2 \
+  method.max_length=4096 \
+  modelpool=SequenceClassificationModelPool/reward_model \
+  taskpool=dummy
+```
+
+## Common Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_epochs` | int | 3 | Max training epochs (-1 = use max_steps). |
+| `max_steps` | int | -1 | Max training steps (-1 = use max_epochs). |
+| `max_steps_per_epoch` | int | -1 | Max steps per epoch. |
+| `accumulate_grad_batches` | int | 1 | Gradient accumulation factor. |
+| `gradient_clip_val` | float | null | Gradient clipping threshold. |
+| `gradient_clip_algorithm` | str | "norm" | Clipping: "value" or "norm". |
+| `checkpoint_save_interval` | str | "epoch" | "epoch" or "step". |
+| `checkpoint_save_frequency` | int | 1 | Checkpoint frequency. |
+| `save_ckpt_type` | str | "lightning" | "lightning", "hf", or "peft". |
+| `save_full_model` | bool | true | Save full model or only trainable params. |
+| `save_optimizer_state` | bool | false | Save optimizer state in checkpoint. |
+| `ckpt_path` | str | null | Path to resume from checkpoint. |
+| `max_length` | int | 4096 | Max sequence length. |
+| `fix_token_embedding` | bool | true | Freeze token embeddings (SFT/RM only). |
+
+## LR Scheduler Configuration
+
+The `_T_max_` placeholder in LR scheduler configs is automatically replaced with the computed total number of training steps. This allows the scheduler to be configured without knowing the dataset size in advance.
+
+## Implementation Details
+
+- [fusion_bench.method.lm_finetune.fullfinetune_sft.FullFinetuneSFT][]
+- [fusion_bench.method.lm_finetune.peftfinetune_sft.PeftFinetuneSFT][]
+- [fusion_bench.method.lm_finetune.bradley_terry_rm.BradleyTerryRewardModeling][]
+
+[^1]: The Bradley-Terry model for reward modeling follows the approach used in InstructGPT and RLHF pipelines.

--- a/docs/algorithms/magmax.md
+++ b/docs/algorithms/magmax.md
@@ -1,0 +1,124 @@
+# MagMax
+
+[MagMax](https://arxiv.org/abs/2407.06322) (Marczak et al., ECCV 2024) is a
+training-free model merging method that selects, **element-wise**, the task
+vector with the **largest absolute magnitude** across tasks.
+
+The intuition is that each fine-tuned model encodes its task knowledge in a
+sparse set of large-magnitude parameter updates. For a given parameter
+position, the task whose update has the highest magnitude is the one that
+"cares most" about that parameter, and its value is the one most likely to
+contain task-relevant signal. Summing or averaging would dilute that signal;
+MagMax keeps it intact.
+
+## Merging rule
+
+Given a pretrained model $\theta_0$ and $T$ fine-tuned models
+$\{\theta_t\}_{t=1}^T$, compute the per-task task vectors:
+
+$$\tau_t = \theta_t - \theta_0$$
+
+For every parameter index $j$ select the task with the maximum absolute
+value at that position:
+
+$$t^\star(j) = \arg\max_{t \in \{1,\dots,T\}} \lvert \tau_t[j] \rvert,
+\qquad
+\tau_\text{max}[j] = \tau_{t^\star(j)}[j]$$
+
+The merged model is then
+
+$$\theta_\text{merged} = \theta_0 + \alpha \cdot \tau_\text{max}$$
+
+where $\alpha$ (`scaling_factor` in the config) scales the merged task
+vector. The official 8-dataset reproduction script uses $\alpha = 0.5$,
+which we adopt as the default.
+
+!!! note "Implementation details"
+    - **Tie-breaking** uses `>=` (later task vectors win on ties), matching
+      the reference implementation.
+    - Integer / boolean buffer keys (e.g. `position_ids`) are skipped and
+      copied through from the pretrained state — the merge only touches
+      floating-point parameters.
+
+## Configuration
+
+```yaml title="config/method/magmax/magmax.yaml"
+--8<-- "config/method/magmax/magmax.yaml"
+```
+
+| Key | Type | Description |
+|---|---|---|
+| `scaling_factor` | float | $\alpha$. Scales the merged max-magnitude task vector before adding it back to $\theta_0$. |
+| `inplace` | bool | If `true`, the loaded pretrained model is mutated in place; otherwise a copy is returned. |
+
+## Examples
+
+### CLI
+
+```bash
+fusion_bench \
+    method=magmax/magmax \
+    method.scaling_factor=0.5 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### Reproduction scripts
+
+Bundled scripts live in [`examples/magmax/`](https://github.com/tanganke/fusion_bench/tree/main/examples/magmax). The paper distinguishes between two protocols (see the example README for details):
+
+- **Independent FT** (default for these CLI scripts) — runs MagMax on the publicly hosted per-task CLIP checkpoints. Faster, no training required, but a few points below the paper because the checkpoints differ.
+    - `clip_vit_base_patch32_TA8.sh`
+    - `clip_vit_base_patch16_TA8.sh`
+    - `clip_vit_base_patch32_TALL14.sh`
+    - `sweep_scaling_factor.sh` — $\alpha$ sweep
+- **Sequential FT** (paper-faithful, headline setting): `sequential_ft_and_merge.py` performs sequential fine-tuning of CLIP on the 8 tasks in the paper's order, saves each task's snapshot, then merges with MagMax and evaluates.
+
+### Programmatic use
+
+```python
+from fusion_bench.method import MagMaxAlgorithm, magmax_merge
+
+# As an Algorithm (with a BaseModelPool):
+algorithm = MagMaxAlgorithm(scaling_factor=0.5)
+merged = algorithm.run(modelpool)
+
+# As a one-shot function on bare nn.Modules:
+merged = magmax_merge(pretrained_model, [m1, m2, m3], scaling_factor=0.5)
+```
+
+## Reproduction results
+
+Numbers obtained on CLIP-ViT-B/32 (TA8: SUN397, Stanford-Cars, RESISC45, EuroSAT, SVHN, GTSRB, MNIST, DTD).
+
+### Independent fine-tuning protocol (`ind-ft`)
+
+Uses the publicly hosted per-task `tanganke/clip-vit-base-patch32_*` checkpoints (each fine-tuned from `_pretrained_` in isolation). $\alpha$ sweep:
+
+| $\alpha$ | 0.3 | 0.4 | 0.5 | **0.6** | 0.7 | 0.8 | 1.0 |
+|---|---|---|---|---|---|---|---|
+| Avg Acc (%) | 66.49 | 69.23 | 70.70 | **71.10** | 70.31 | 68.80 | 63.59 |
+
+For reference, on the same checkpoints: Task Arithmetic ($\alpha=0.3$) → 77.14 % and TIES Merging ($\alpha=0.3$) → 77.60 % on CLIP-ViT-B/16 — i.e. all three task-vector methods sit within ~2 points of one another. The MagMax paper's headline numbers (~84 % on ViT-B/16) come from the `seq-ft` protocol below, not from `ind-ft` checkpoints.
+
+### Sequential fine-tuning protocol (`seq-ft`, paper-faithful)
+
+Trained end-to-end with `examples/magmax/sequential_ft_and_merge.py` on CLIP-ViT-B/32, 2500 steps per task in the paper's task order, then merged with `scaling_factor = 0.5`:
+
+| Stanford-Cars | MNIST | EuroSAT | SVHN | RESISC45 | SUN397 | DTD | GTSRB | **Average** |
+|---|---|---|---|---|---|---|---|---|
+| 71.74 | 99.09 | 96.67 | 94.39 | 85.59 | 68.80 | 58.99 | 69.21 | **80.56** |
+
+`seq-ft` outperforms `ind-ft` by ~10 percentage points on B/32, mirroring the paper's central observation that MagMax recovers near-multi-task performance from sequentially fine-tuned snapshots. The paper reports ~84 % on CLIP-ViT-B/16 in the same setting; our B/32 result sits in the expected B/32-to-B/16 scaling band.
+
+## Reference
+
+```bibtex
+@inproceedings{marczak2024magmax,
+  title     = {{MagMax}: Leveraging Model Merging for Seamless Continual Learning},
+  author    = {Marczak, Daniel and Twardowski, Bart{\l}omiej and
+               Trzci{\'n}ski, Tomasz and Cygert, Sebastian},
+  booktitle = {European Conference on Computer Vision (ECCV)},
+  year      = {2024},
+}
+```

--- a/docs/algorithms/model_stock.md
+++ b/docs/algorithms/model_stock.md
@@ -1,0 +1,174 @@
+# Model Stock
+
+Model Stock is a parameter-space merging method that leverages the geometric relationship between fine-tuned models. Rather than using fixed weights, it computes an interpolation ratio for each parameter group based on the angle between fine-tuned models relative to a pretrained anchor. The intuition is that when two fine-tuned models move in similar directions from the pretrained model, they can be merged more aggressively; when they diverge, the pretrained model acts as a stabilizer[^1].
+
+<figure markdown="span">
+  ![Model Stock](images/model_stock.png){ width="500" }
+  <figcaption>Model Stock: Angle-based interpolation between fine-tuned models and pretrained anchor. Credit to <sup id="fnref:1"><a class="footnote-ref" href="#fn:1">1</a></sup></figcaption>
+</figure>
+
+**Core Idea**. Given a pretrained model $\theta_0$ and fine-tuned models $\theta_1, \theta_2, \dots, \theta_K$, Model Stock computes the angle between the fine-tuned models' displacement vectors in parameter space. The interpolation ratio $t$ is then derived from this angle, yielding a merge:
+
+$$\theta_{merged} = t \cdot \bar{\theta}_{ft} + (1 - t) \cdot \theta_0$$
+
+where $\bar{\theta}_{ft}$ is the average of the fine-tuned models, and $t$ is computed from the cosine of the angles between pairs of fine-tuned models.
+
+## Mathematical Formulation
+
+### Two-Model Case
+
+For two fine-tuned models $\theta_1$ and $\theta_2$, the angle between their displacement vectors relative to $\theta_0$ is computed per-parameter-group:
+
+$$\cos \phi = \frac{(\theta_1 - \theta_0) \cdot (\theta_2 - \theta_0)}{\|\theta_1 - \theta_0\| \cdot \|\theta_2 - \theta_0\|}$$
+
+The interpolation ratio is then:
+
+$$t = \frac{K \cos \phi}{(K-1) \cos \phi + 1}$$
+
+where $K = 2$ for the two-model case. The merged model is:
+
+$$\theta_{merged} = t \cdot \frac{\theta_1 + \theta_2}{2} + (1 - t) \cdot \theta_0$$
+
+When $\cos \phi$ is close to 1 (the models moved in the same direction), $t \approx 1$ and the merge relies heavily on the fine-tuned models. When $\cos \phi$ is near 0 or negative (the models diverged), $t$ shrinks, and the pretrained anchor contributes more.
+
+### N-Model Case
+
+For $K > 2$ fine-tuned models, Model Stock computes the average angle across all pairs:
+
+1. Compute pairwise angles for all $\binom{K}{2}$ pairs.
+2. Average the angles per parameter group.
+3. Apply the same ratio formula using the averaged angle and $K$.
+4. Average the fine-tuned models: $\bar{\theta}_{ft} = \frac{1}{K} \sum_{i=1}^{K} \theta_i$.
+5. Merge: $\theta_{merged} = t \cdot \bar{\theta}_{ft} + (1 - t) \cdot \theta_0$.
+
+### Angle Computation
+
+The `compute_angle()` function calculates the angle between two state dictionaries relative to a reference:
+
+```python
+def compute_angle(state_dict_1, state_dict_2, ref_state_dict, ignore_keys=[], return_cos=False):
+    for key in ref_state_dict:
+        vector1 = (state_dict_1[key] - ref_state_dict[key]).clone().detach()
+        vector2 = (state_dict_2[key] - ref_state_dict[key]).clone().detach()
+        cosine_val = sum(vector1 * vector2) / (sqrt(sum(vector1^2) * sum(vector2^2)) + EPS)
+        angle = acos(cosine_val)  # in radians
+    return angle_dict
+```
+
+### Ratio Computation
+
+```python
+def compute_ratio(angle_dict, k=2):
+    for key in angle_dict:
+        angle = rad2deg(angle_dict[key])
+        ratio = k * cos(angle) / ((k - 1) * cos(angle) + 1 + EPS)
+    return ratio_dict
+```
+
+### Weight Merge
+
+```python
+def merge_weights(w1, w2, w0, ratio):
+    w12 = (w1 + w2) / 2  # average of fine-tuned models
+    for key, r in ratio.items():
+        w_merge[key] = w12[key] * r + w0[key] * (1.0 - r)
+    return w_merge
+```
+
+## Examples
+
+### CLI Usage
+
+Configuration template:
+
+```yaml title="config/method/model_stock/model_stock.yaml"
+--8<-- "config/method/model_stock/model_stock.yaml"
+```
+
+Run Model Stock:
+
+```bash
+fusion_bench method=model_stock/model_stock \
+    method.model_save_path=outputs/model_stock_merged \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_two_tasks \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_two_tasks
+```
+
+The default configuration ignores certain CLIP-specific parameters that are not fine-tuned:
+
+```yaml
+ignore_keys:
+  - "model.positional_embedding"
+  - "model.text_projection"
+  - "model.logit_scale"
+  - "model.token_embedding.weight"
+  - "model.ln_final.weight"
+  - "model.ln_final.bias"
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.model_stock import ModelStock
+
+# Instantiate the algorithm
+algorithm = ModelStock(
+    ignore_keys=[],
+    model_save_path="outputs/merged",
+)
+
+# Run the algorithm on a model pool
+# The model pool must contain a pretrained model (_pretrained_) and at least 2 fine-tuned models
+merged_model = algorithm.run(modelpool)
+```
+
+## Implementation Details
+
+### Algorithm Steps
+
+The `ModelStock.run()` method follows these steps:
+
+1. **Load Models**: Load the pretrained model and all fine-tuned models from the model pool.
+2. **Compute Angles**:
+   - For 2 models: compute pairwise angles directly.
+   - For $N$ models: compute all pairwise angles and average them.
+3. **Compute Ratios**: Convert angles to interpolation ratios using the `compute_ratio()` formula.
+4. **Merge Weights**:
+   - For 2 models: apply `merge_weights()` directly.
+   - For $N$ models: average the fine-tuned models, then apply the ratio formula.
+5. **Save**: If `model_save_path` is set, save the merged model and generate a model card.
+
+### Key Features
+
+- **Per-Parameter-Group Ratios**: Each parameter (e.g., each layer's weight matrix) gets its own interpolation ratio, allowing fine-grained control.
+- **Ignore Keys**: Parameters that were not fine-tuned (e.g., positional embeddings) can be excluded from angle computation.
+- **Shape Validation**: Parameters with mismatched shapes are skipped with a warning.
+- **LazyStateDict Support**: Works with FusionBench's lazy state dict for memory-efficient merging of large models.
+- **Model Card Generation**: Automatically generates a README model card when saving.
+
+### Model Stock Class
+
+```python
+@auto_register_config
+class ModelStock(SimpleProfilerMixin, BaseAlgorithm):
+    def __init__(
+        self,
+        ignore_keys: Optional[List[str]] = None,
+        model_save_path: Optional[str] = None,
+        model_save_kwargs: Optional[DictConfig] = None,
+    ):
+        ...
+```
+
+The `@auto_register_config` decorator automatically maps constructor arguments to YAML config keys.
+
+## Hyperparameter Guidelines
+
+- **`ignore_keys`**: Exclude parameters that were frozen during fine-tuning. For CLIP vision models, this typically includes positional embeddings, text projection, logit scale, and text token embeddings.
+- **`model_save_path`**: Set to save the merged model. Supports both standard `nn.Module` and HuggingFace `PreTrainedModel` saving.
+
+## Implementation Details
+
+- [ModelStock][fusion_bench.method.model_stock.ModelStock]
+
+[^1]: (2024) Model Stock: All we need is just a few fine-tuned models. https://arxiv.org/abs/2403.19522

--- a/docs/algorithms/moe_pruner.md
+++ b/docs/algorithms/moe_pruner.md
@@ -1,0 +1,114 @@
+# MoE Pruner
+
+MoE Pruner applies post-training magnitude pruning to Mixture-of-Experts (MoE) language models. It supports both Mixtral and DeepSeek V2 architectures, pruning the linear layers within expert modules based on importance scores derived from calibration data.
+
+**The Pruning Strategy**. MoE Pruner uses a layer-by-layer pruning approach with activation-based importance scoring:
+
+1. **Calibration Data Preparation**: The algorithm loads calibration data (from the C4 dataset) and propagates it through the model layer by layer, capturing the inputs to each layer.
+
+2. **Importance Score Computation**: For each layer, forward hooks are registered on all linear layers within the expert modules. A gate-level hook captures which experts are activated for each token (via the MoE routing mechanism). The importance of each weight is computed as the product of the absolute weight value and the accumulated activation magnitude.
+
+3. **Magnitude Pruning**: Weights are pruned based on their importance scores. The least important weights (lowest scores) are set to zero.
+
+**Supported Pruning Types**:
+- **Unstructured pruning**: A fraction `sparsity_ratio` of weights are pruned (e.g., 0.5 = 50% sparsity).
+- **Semistructured pruning**: Weights are pruned in an n:m pattern (e.g., 2:4 means 2 out of every 4 consecutive weights are pruned).
+
+**Architecture-Specific Hooks**: The implementation provides specialized hook functions for both Mixtral and DeepSeek V2 models:
+
+- **Mixtral**: `MoEPrunerHookFnForMixtralLinear` and `MoEPrunerHookFnForMixtralGate`
+- **DeepSeek V2**: `MoEPrunerHookFnForDeepseekV2Linear` and `MoEPrunerHookFnForDeepseekV2Gate`
+
+For DeepSeek V2, the algorithm handles both MoE layers (with expert modules) and dense MLP layers, skipping the latter without pruning.
+
+## Layer-by-Layer Processing
+
+The pruning proceeds layer by layer to manage memory:
+
+1. The inputs to the current layer are moved to the layer's device (supporting device mapping for large models).
+2. Forward hooks are registered on all expert linear layers and the gate.
+3. Calibration samples are forwarded through the layer.
+4. Importance scores are computed and hooks removed.
+5. Pruning is applied based on the scores.
+6. The layer's outputs become the inputs for the next layer.
+
+## Examples
+
+### CLI Usage
+
+```yaml title="config/method/moe_pruner/moe_pruner.yaml"
+--8<-- "config/method/moe_pruner/moe_pruner.yaml"
+```
+
+```bash
+fusion_bench \
+  method=moe_pruner/moe_pruner \
+  method.sparsity_ratio=0.5 \
+  method.prune_type=unstructured \
+  method.nsamples=100 \
+  method.max_seqlen=2048 \
+  modelpool=CausalLMPool/mixtral-8x7b
+```
+
+### Semistructured Pruning
+
+For n:m structured sparsity (e.g., compatible with NVIDIA Tensor Cores):
+
+```bash
+fusion_bench \
+  method=moe_pruner/moe_pruner \
+  method.prune_type=semistructured \
+  method.n=2 \
+  method.m=4 \
+  modelpool=CausalLMPool/mixtral-8x7b
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `nsamples` | int | 100 | Number of calibration samples. |
+| `seed` | int | 42 | Random seed for calibration data selection. |
+| `device` | str | "cuda" | Device for computation. |
+| `max_seqlen` | int | 2048 | Maximum sequence length for calibration data. |
+| `prune_type` | str | "unstructured" | Pruning type: "unstructured" or "semistructured". |
+| `sparsity_ratio` | float | 0.5 | Fraction of weights to prune (unstructured only). |
+| `n` | int | 2 | N in n:m semistructured pruning. |
+| `m` | int | 4 | M in n:m semistructured pruning. |
+
+### API Usage
+
+```python
+from fusion_bench.method.moe_pruner import MoEPruner
+
+algorithm = MoEPruner(
+    nsamples=100,
+    seed=42,
+    device="cuda",
+    max_seqlen=2048,
+    prune_type="unstructured",
+    sparsity_ratio=0.5,
+    n=2,
+    m=4,
+)
+pruned_model = algorithm.run(modelpool)
+```
+
+## Calibration Data Caching
+
+Calibration data preparation is automatically cached to disk (`outputs/cache/{model_name}/calibration_data.pkl`) to avoid reprocessing on subsequent runs.
+
+## Supported Models
+
+- **MixtralForCausalLM** (e.g., Mixtral-8x7B)
+- **DeepseekV2ForCausalLM** (e.g., DeepSeek V2/V2.5)
+
+## Implementation Details
+
+- [fusion_bench.method.moe_pruner.moe_pruner.MoEPruner][]
+- [fusion_bench.method.moe_pruner.hooks.mixtral.MoEPrunerHookFnForMixtralGate][]
+- [fusion_bench.method.moe_pruner.hooks.mixtral.MoEPrunerHookFnForMixtralLinear][]
+- [fusion_bench.method.moe_pruner.hooks.deepseek_v2.MoEPrunerHookFnForDeepseekV2Gate][]
+- [fusion_bench.method.moe_pruner.hooks.deepseek_v2.MoEPrunerHookFnForDeepseekV2Linear][]
+
+[^1]: Adapted from the WANDA pruning methodology: https://github.com/locuslab/wanda

--- a/docs/algorithms/opcm.md
+++ b/docs/algorithms/opcm.md
@@ -1,0 +1,280 @@
+# OPCM (Orthogonal Projection for Continual Merging)
+
+OPCM addresses the continual model merging problem, where models arrive sequentially and must be merged one by one into a single model. The core insight is that when merging a new task model into an existing merged model, the task vectors often have overlapping components that cause negative interference. OPCM uses Singular Value Decomposition (SVD) to project each new task vector into the subspace orthogonal to the dominant directions of the current merged task vector[^1].
+
+<figure markdown="span">
+  ![OPCM](images/opcm.png){ width="600" }
+  <figcaption>OPCM: SVD-based orthogonal projection for continual merging. Credit to <sup id="fnref:1"><a class="footnote-ref" href="#fn:1">1</a></sup></figcaption>
+</figure>
+
+**The Continual Merging Setting**. In the continual (or online) setting, models $\theta_1, \theta_2, \dots, \theta_K$ arrive sequentially. After merging the first $t$ models, the merged model $\theta^{(t)}$ must be updated to incorporate $\theta_{t+1}$ without reprocessing $\theta_1, \dots, \theta_t$. OPCM maintains a running merge that preserves previous task knowledge while incorporating new tasks.
+
+## Mathematical Formulation
+
+Let $\theta_0$ be the pretrained (anchor) model. Given the current merged model $\theta^{(t-1)}$ and a new task model $\theta_t$, OPCM computes:
+
+1. **Task Vectors**:
+   $$\tau_{merged}^{(t-1)} = \theta^{(t-1)} - \theta_0$$
+   $$\tau_{new} = \theta_t - \theta_0$$
+
+2. **SVD of Merged Task Vector** (for linear weight matrices):
+   $$\tau_{merged}^{(t-1)} = U \Sigma V^\top$$
+
+3. **Projection and Zeroing**:
+   Project the new task vector into the SVD basis of the merged task vector:
+   $$P = U^\top \tau_{new} V$$
+   Zero out the diagonal of $P$ to remove alignment with singular vectors:
+   $$P_{ii} \leftarrow 0$$
+   Zero out the top-left block (dominant singular directions) up to a split rank $r$:
+   $$P_{ij} \leftarrow 0 \quad \text{for } i, j \leq r$$
+
+   The split rank $r$ is determined by the parameter $\alpha$: it is the smallest index such that the cumulative sum of singular values exceeds a fraction $\alpha$ of the total:
+   $$r = \min \left\{ k : \frac{\sum_{i=1}^k \sigma_i}{\sum_{i} \sigma_i} > \alpha \right\}$$
+
+4. **Reconstruct the Cleaned Task Vector**:
+   $$\tilde{\tau}_{new} = U P V^\top$$
+
+5. **Update the Merged Model**:
+   $$\theta^{(t)} = \theta_0 + \frac{\lambda_{t-1} \tau_{merged}^{(t-1)} + \tilde{\tau}_{new}}{\lambda_t}$$
+
+   where $\lambda_t$ is a scaling factor computed to maintain a stable task vector norm, approximately growing as $\sqrt{t}$.
+
+For non-linear parameters (biases, LayerNorm weights), OPCM uses a simpler averaging formula without SVD projection:
+$$\theta^{(t)} = \theta_0 + \frac{\lambda_{t-1} (\theta^{(t-1)} - \theta_0) + (\theta_t - \theta_0)}{\lambda_t}$$
+
+## OPCM Variants in FusionBench
+
+### 1. OPCM (General)
+
+The `OPCM` class in `opcm_general.py` is the general-purpose implementation with support for Ray-based distributed merging.
+
+```python
+OPCM(
+    alpha=0.5,                    # SVD projection threshold
+    shuffle_order=True,           # shuffle model order
+    seed=None,                    # random seed
+    save_on_every_step=True,      # save checkpoint at each step
+    evaluate_on_every_step=False, # evaluate at each step
+    num_ray_actors=0,             # parallel actors for distributed merge
+)
+```
+
+### 2. OPCM for CLIP
+
+The `OPCMForCLIP` class in `opcm.py` is a CLIP-specific implementation that includes task pool integration for evaluation at each merging step.
+
+```python
+OPCMForCLIP(
+    alpha=0.5,
+    shuffle_order=True,
+    seed=None,
+    save_on_every_step=True,
+    evaluate_on_every_step=True,
+)
+```
+
+### 3. Continual Task Arithmetic
+
+A baseline continual merging method that applies task arithmetic incrementally without SVD projection.
+
+```python
+ContinualTaskArithmeticForCLIP(
+    scaling_factor=0.3,
+    shuffle_order=True,
+    seed=None,
+    save_on_every_step=True,
+    evaluate_on_every_step=True,
+)
+```
+
+### 4. Continual TIES-Merging
+
+A continual variant of TIES-Merging that resolves sign conflicts at each step.
+
+```python
+ContinualTiesMergingForCLIP(
+    scaling_factor=0.5,
+    threshold=20,
+    remove_keys=[],
+    merge_func="sum",
+    shuffle_order=True,
+    seed=None,
+    save_on_every_step=True,
+    evaluate_on_every_step=True,
+)
+```
+
+### 5. Continual Weight Average
+
+A simple incremental averaging baseline: $\theta^{(t)} = \frac{t \cdot \theta^{(t-1)} + \theta_t}{t + 1}$.
+
+```python
+ContinualWeightAverageForCLIP(
+    shuffle_order=True,
+    seed=None,
+    save_on_every_step=True,
+    evaluate_on_every_step=True,
+)
+```
+
+## SVD Projection Details
+
+The SVD projection is the core of OPCM. The key idea is:
+
+1. **Dominant directions** of the merged task vector represent the "shared" knowledge accumulated so far.
+2. **New task vectors** projected onto these dominant directions cause interference.
+3. By **zeroing out** the projection onto the top-$r$ singular directions, we keep the new information that is *orthogonal* (novel) to what has been merged.
+4. The **diagonal zeroing** step removes alignment with each singular vector individually, preventing self-reinforcement.
+
+The parameter $\alpha$ controls the aggressiveness:
+- $\alpha = 0.5$ means we zero out directions explaining 50% of the variance.
+- Higher $\alpha$ zeros out more directions, being more conservative about what gets merged.
+- Lower $\alpha$ zeros out fewer directions, allowing more overlap.
+
+## Examples
+
+### CLI Usage
+
+Configuration template for OPCM:
+
+```yaml title="config/method/opcm/opcm.yaml"
+--8<-- "config/method/opcm/opcm.yaml"
+```
+
+Run OPCM for CLIP:
+
+```bash
+fusion_bench method=opcm/opcm \
+    method.alpha=0.5 \
+    method.shuffle_order=true \
+    method.evaluate_on_every_step=true \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Configuration for the general OPCM (with Ray support):
+
+```yaml title="config/method/opcm/opcm_general.yaml"
+--8<-- "config/method/opcm/opcm_general.yaml"
+```
+
+Run general OPCM with distributed merging:
+
+```bash
+fusion_bench method=opcm/opcm_general \
+    method.alpha=0.5 \
+    method.num_ray_actors=4 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Configuration for continual task arithmetic:
+
+```yaml title="config/method/opcm/task_arithmetic.yaml"
+--8<-- "config/method/opcm/task_arithmetic.yaml"
+```
+
+Run continual task arithmetic:
+
+```bash
+fusion_bench method=opcm/task_arithmetic \
+    method.scaling_factor=0.3 \
+    method.shuffle_order=true \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Configuration for continual TIES-Merging:
+
+```yaml title="config/method/opcm/ties_merging.yaml"
+--8<-- "config/method/opcm/ties_merging.yaml"
+```
+
+Run continual TIES-Merging:
+
+```bash
+fusion_bench method=opcm/ties_merging \
+    method.scaling_factor=0.5 \
+    method.threshold=20 \
+    method.merge_func=sum \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+Configuration for continual weight average:
+
+```yaml title="config/method/opcm/weight_average.yaml"
+--8<-- "config/method/opcm/weight_average.yaml"
+```
+
+Run continual weight average:
+
+```bash
+fusion_bench method=opcm/weight_average \
+    method.shuffle_order=true \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.opcm import OPCM
+
+# Instantiate the algorithm
+algorithm = OPCM(
+    alpha=0.5,
+    shuffle_order=True,
+    save_on_every_step=True,
+    evaluate_on_every_step=False,
+)
+
+# Run continual merging on a model pool
+merged_model = algorithm.run(modelpool)
+```
+
+## Runtime Behavior
+
+All OPCM variants share these behavioral features:
+
+1. **Sequential Processing**: Models are processed one at a time. The order can be shuffled (`shuffle_order=True`) or fixed.
+2. **Checkpoint Saving**: When `save_on_every_step=True`, intermediate merged models are saved to `{log_dir}/checkpoints/merged_model_{step}/`.
+3. **Evaluation**: When `evaluate_on_every_step=True`, the merged model is evaluated after each step. Reports are saved as `report_{step}.json`.
+4. **Logging**: TensorBoard logs track task vector norms, $\lambda_t$ values, and other metrics.
+5. **Progress Bars**: Uses `tqdm` for both model-level and layer-level progress tracking.
+6. **Profiling**: Built-in `SimpleProfilerMixin` reports timing for loading, merging, saving, and evaluation.
+
+## Distributed Merging with Ray
+
+The general `OPCM` class supports distributed merging via Ray actors. Set `num_ray_actors > 0` to spawn Ray actors that process layers in parallel:
+
+```bash
+fusion_bench method=opcm/opcm_general \
+    method.num_ray_actors=8 \
+    ...
+```
+
+Each Ray actor independently computes the SVD projection for assigned linear layers, while the main process handles bias and non-linear parameters.
+
+## Utility Functions
+
+Key utilities in `fusion_bench/method/opcm/utils.py`:
+
+- **`svd(w, full_matrices, accelerator)`**: Performs SVD on a weight tensor with optional device transfer.
+- **`frobenius_inner_product(w1, w2)`**: Computes the Frobenius inner product of two matrices.
+- **`get_task_vector_norm(model, pretrained_model)`**: Computes the L2 norm of the task vector.
+
+## Hyperparameter Guidelines
+
+- **`alpha`**: Controls the fraction of singular directions to zero out. Typical values: 0.3-0.7. Higher values are more conservative, zeroing out more of the new task's overlap with existing knowledge.
+- **`shuffle_order`**: Randomizing model order can help prevent bias toward earlier models. Set `seed` for reproducibility.
+
+## Implementation Details
+
+- [OPCM][fusion_bench.method.opcm.OPCM]
+- [OPCMForCLIP][fusion_bench.method.opcm.OPCMForCLIP]
+- [ContinualTaskArithmeticForCLIP][fusion_bench.method.opcm.ContinualTaskArithmeticForCLIP]
+- [ContinualTiesMergingForCLIP][fusion_bench.method.opcm.ContinualTiesMergingForCLIP]
+- [ContinualWeightAverageForCLIP][fusion_bench.method.opcm.ContinualWeightAverageForCLIP]
+
+[^1]: (ICML 2024) Tang et al. Merging Multi-Task Models via Weight-Ensembling Mixture of Experts. https://arxiv.org/abs/2402.00433

--- a/docs/algorithms/randes.md
+++ b/docs/algorithms/randes.md
@@ -1,0 +1,290 @@
+# RandES (Random Erasure Superposition)
+
+RandES is a model superposition and retrieval framework that compresses multiple fine-tuned models into a single superposed representation, from which individual models can be later retrieved. By applying random linear transformations (erasure matrices) to each model's parameters and superposing the transformed parameters, RandES enables storing $K$ models in approximately the space of one[^1].
+
+<figure markdown="span">
+  ![RandES](images/randes.png){ width="600" }
+  <figcaption>RandES: Random erasure and superposition for compact multi-model storage. Credit to <sup id="fnref:1"><a class="footnote-ref" href="#fn:1">1</a></sup></figcaption>
+</figure>
+
+**Core Idea**. Each model's parameters are transformed by a model-specific random matrix, then all transformed parameters are summed into a single superposed tensor. To retrieve a specific model, the superposed tensor is multiplied by the retrieval matrix (the inverse or pseudo-inverse of the model's erasure matrix). The randomization ensures that the superposition does not cause catastrophic interference.
+
+## Mathematical Formulation
+
+Given $K$ models with parameters $\{\theta_i\}_{i=1}^K$ and a pretrained model $\theta_0$:
+
+### Compression Phase
+
+For each target layer with parameter matrix $W_i \in \mathbb{R}^{d_{out} \times d_{in}}$ of model $i$, apply a random transformation matrix $M_i$:
+
+$$\tilde{W}_i = W_i M_i$$
+
+The superposed layer is:
+
+$$W_{superposed} = \sum_{i=1}^{K} \tilde{W}_i = \sum_{i=1}^{K} W_i M_i$$
+
+### Retrieval Phase
+
+To retrieve model $j$, apply the retrieval matrix $R_j = M_j^{-1}$ (or $M_j^\top$ for orthogonal matrices):
+
+$$\hat{W}_j = W_{superposed} R_j = \sum_{i=1}^{K} W_i M_i M_j^{-1}$$
+
+When $M_i$ are independent random orthogonal/diagonal matrices, the cross-terms $W_i M_i M_j^{-1}$ for $i \neq j$ become noise that averages out, while the desired term $W_j$ is recovered.
+
+## Erasure Matrix Modes
+
+RandES supports multiple erasure matrix modes, each with different properties:
+
+### 1. Random Binary Diagonal Matrix (`random_binary_diagonal_matrix`)
+
+Each model $i$ gets a diagonal matrix with entries $\pm 1$, generated from a Bernoulli distribution with $p=0.5$:
+
+$$M_i = \text{diag}(s_{i,1}, s_{i,2}, \dots, s_{i,d_{in}}), \quad s_{i,j} \in \{-1, +1\}$$
+
+Compression: element-wise Hadamard product $\tilde{W}_i = W_i \odot M_i$.
+Retrieval: $\hat{W}_i = W_{superposed} \odot M_i$ (since $M_i^{-1} = M_i$ for $\pm 1$ diagonal).
+
+This mode is highly efficient and uses only 1 byte per element for context storage (the sign bits).
+
+### 2. Random Rotation Matrix (`random_rotation_matrix`)
+
+Each model gets an orthogonal rotation matrix sampled from the orthogonal group (using `scipy.stats.ortho_group`):
+
+$$M_i \in \mathbb{R}^{d_{in} \times d_{in}}, \quad M_i^\top M_i = I$$
+
+Compression: matrix multiplication $\tilde{W}_i = W_i M_i$.
+Retrieval: $\hat{W}_i = W_{superposed} M_i^\top$ (since $M_i^{-1} = M_i^\top$).
+
+### 3. Random Dense Matrix (`random_dense_matrix`)
+
+Each model gets a random Gaussian matrix. The pseudo-inverse is used for retrieval:
+
+$$M_i \sim \mathcal{N}(0, I)^{d_{in} \times d_{in}}$$
+$$R_i = M_i^+ = (M_i^\top M_i)^{-1} M_i^\top$$
+
+### 4. Random Diagonal Matrix (`random_diagonal_matrix`)
+
+Each model gets a diagonal matrix with Gaussian entries. Retrieval uses element-wise division:
+
+$$M_i = \text{diag}(g_{i,1}, g_{i,2}, \dots), \quad g_{i,j} \sim \mathcal{N}(0, 1)$$
+$$R_i = \text{diag}(1/g_{i,1}, 1/g_{i,2}, \dots)$$
+
+### 5. Identity Matrix (`identity_matrix`)
+
+The identity matrix -- no transformation. This serves as a baseline (simple superposition without randomization).
+
+## Layer Shifting
+
+RandES supports layer shifting, where each model's layers are permuted before superposition:
+
+- **Fixed shift** (`shift_layers > 0`): Each model $i$ has its layers cyclically shifted by $i \times \text{shift\_layers}$ positions.
+- **Random shift** (`shift_layers = -1`): Each model gets a random permutation of its layers.
+
+Layer shifting further decorrelates the superposed representations of different models.
+
+## Absorber
+
+Non-target layers (e.g., LayerNorm, embeddings) can be "absorbed" rather than superposed. The absorber options are:
+
+- **`average`**: Use the average of all models' non-target layers.
+- **`pretrained`**: Use the pretrained model's non-target layers.
+- **`None`**: No absorption -- all layers are superposed.
+
+## RandES Variants in FusionBench
+
+### 1. Superposed Model Soup
+
+The `SuperposedModelSoupAlgorithm` compresses full model weights into a superposed representation. Models are retrieved as individual weights.
+
+```python
+from fusion_bench.method.randes import SuperposedModelSoupAlgorithm
+
+algorithm = SuperposedModelSoupAlgorithm(
+    mode="random_binary_diagonal_matrix",
+    target_layer=["mlp_w", "attn_w"],
+    random_seed=42,
+    different_across_layers=True,
+    shift_layers=0,
+    absorber="average",
+    ms_mode="average",     # "average" or "original"
+    dropout_rate=1,        # process every Nth target layer
+)
+
+result = algorithm.run(modelpool)
+# result = {"models": {model_name: retrieved_model, ...}, "metadata": {...}}
+```
+
+### 2. Superposed Task Arithmetic
+
+The `SuperposedTaskArithmeticAlgorithm` compresses task vectors (differences from pretrained) rather than full weights. This is more efficient because the pretrained model serves as an anchor and does not need to be stored in the superposed representation.
+
+$$\tau_i = \theta_i - \theta_0$$
+$$W_{superposed} = \sum_i \tau_i M_i$$
+
+Retrieval yields the task vector, which is then added back to the pretrained model:
+
+$$\hat{\theta}_i = \theta_0 + \lambda \cdot \text{retrieve}(W_{superposed}, M_i)$$
+
+```python
+from fusion_bench.method.randes import SuperposedTaskArithmeticAlgorithm
+
+algorithm = SuperposedTaskArithmeticAlgorithm(
+    mode="random_binary_diagonal_matrix",
+    target_layer=["mlp_w", "attn_w"],
+    random_seed=42,
+    scaling_factor=0.5,
+    model_path=None,
+)
+```
+
+### 3. Superposed Task Arithmetic with LoRA
+
+The `SuperposedTaskArithmeticLoRAAlgorithm` works with LoRA adapters. It compresses the LoRA weight matrices ($A$ and $B$), and during retrieval, reconstructs the merged LoRA weight as $W_{lora} = B \cdot A$ before adding to the pretrained model.
+
+## Common Configuration
+
+All RandES variants share these base parameters defined in `SuperposedAlgorithmBase`:
+
+| Parameter | Description |
+|---|---|
+| `mode` | Erasure matrix type |
+| `target_layer` | Layers to apply superposition to (e.g., `["mlp_w", "attn_w"]`) |
+| `random_seed` | Seed for random matrix generation |
+| `different_across_layers` | Use different matrices per layer |
+| `rank` | Rank for SVD-based decomposition |
+| `random_components` | Use random SVD components |
+| `shift_layers` | Layer shift amount (0 = none, -1 = random) |
+| `absorber` | How to handle non-target layers |
+| `debug` | Debug level (0-2) |
+| `ms_mode` | For model soup: "average" or "original" |
+| `verbose` | Verbosity level |
+| `dropout_rate` | Process every Nth target layer |
+
+### Target Layer Filtering
+
+The `target_layer` parameter accepts these values:
+- `"mlp_w"`: MLP weight matrices (excluding biases)
+- `"attn_w"`: Attention weight matrices (excluding biases)
+- `"mlp"`: All MLP parameters (including biases)
+- `"attn"`: All attention parameters (including biases)
+- `"all"`: All parameters
+
+### Dropout Rate
+
+The `dropout_rate` parameter controls sparsity of the target layers. If `dropout_rate=2`, only every 2nd target layer is compressed; the rest use the absorber. This reduces storage while maintaining retrieval quality.
+
+## Analysis Utilities
+
+RandES provides comprehensive analysis utilities in `fusion_bench/method/randes/base_algorithm.py`:
+
+- **`cosine_similarity(tensor1, tensor2)`**: Compute cosine similarity between two tensors.
+- **`svd_and_partition(A, num_chunks)`**: Partition SVD into chunks for subspace analysis.
+- **`compute_svd_subspace_similarity(ref, retrieval, num_chunks)`**: Evaluate how well retrieved weights match the original in SVD subspace.
+- **`pairwise_cosine_similarity_matrix(tensors)`**: Compute all-pairs cosine similarity.
+- **`compare_models(state_dict1, state_dict2)`**: Comprehensive comparison including L2 differences and cosine similarities at layer and global levels.
+
+## Examples
+
+### CLI Usage
+
+Configuration for Superposed Model Soup:
+
+```yaml title="config/method/randes/superposed_model_soup.yaml"
+--8<-- "config/method/randes/superposed_model_soup.yaml"
+```
+
+Run Superposed Model Soup:
+
+```bash
+fusion_bench method=randes/superposed_model_soup \
+    method.mode=random_binary_diagonal_matrix \
+    method.target_layer=mlp_w,attn_w \
+    method.random_seed=42 \
+    method.absorber=average \
+    method.ms_mode=average \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=...
+```
+
+Configuration for Superposed Task Arithmetic:
+
+```yaml title="config/method/randes/superposed_task_arithmetic.yaml"
+--8<-- "config/method/randes/superposed_task_arithmetic.yaml"
+```
+
+Run Superposed Task Arithmetic:
+
+```bash
+fusion_bench method=randes/superposed_task_arithmetic \
+    method.mode=random_binary_diagonal_matrix \
+    method.scaling_factor=0.5 \
+    method.shift_layers=0 \
+    method.absorber=pretrained \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=...
+```
+
+Configuration for Superposed Task Arithmetic with LoRA:
+
+```yaml title="config/method/randes/superposed_task_arithmetic_lora.yaml"
+--8<-- "config/method/randes/superposed_task_arithmetic_lora.yaml"
+```
+
+Run Superposed Task Arithmetic LoRA:
+
+```bash
+fusion_bench method=randes/superposed_task_arithmetic_lora \
+    method.mode=random_binary_diagonal_matrix \
+    method.scaling_factor=0.5 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8_lora \
+    taskpool=...
+```
+
+### API Usage
+
+```python
+from fusion_bench.method.randes import SuperposedTaskArithmeticAlgorithm
+
+algorithm = SuperposedTaskArithmeticAlgorithm(
+    mode="random_binary_diagonal_matrix",
+    target_layer=["mlp_w", "attn_w"],
+    random_seed=42,
+    different_across_layers=True,
+    shift_layers=0,
+    absorber="pretrained",
+    scaling_factor=0.5,
+    model_path="outputs/retrieved_models.pt",
+)
+
+result = algorithm.run(modelpool)
+models = result["models"]  # dict of {model_name: retrieved_model}
+metadata = result["metadata"]  # dict with analysis info
+```
+
+## Storage Efficiency
+
+One of the key benefits of RandES is storage efficiency. The metadata returned includes:
+
+- **`total_gb_original`**: Total storage of the original models (in GB).
+- **`total_gb_retrieved`**: Total storage of the superposed + context representation.
+- **`nonzero_parameter_count`**: Number of non-zero parameters in the superposed representation.
+- **`nonzero_param_count_context`**: Number of non-zero parameters in the context (retrieval matrices).
+
+For the `random_binary_diagonal_matrix` mode, context storage is minimal (1 byte per element for the sign bits), making it highly storage-efficient.
+
+## Hyperparameter Guidelines
+
+- **`mode`**: Use `random_binary_diagonal_matrix` for best storage efficiency. Use `random_rotation_matrix` for better retrieval quality at the cost of larger context.
+- **`target_layer`**: Focus on MLP and attention weights (`["mlp_w", "attn_w"]`) as they contain the bulk of task-specific knowledge.
+- **`shift_layers`**: Use `-1` (random shuffle) for maximum decorrelation. Use a fixed value for controlled experiments.
+- **`dropout_rate`**: Higher values (e.g., 2 or 3) skip more layers, reducing storage but potentially degrading retrieval quality.
+- **`absorber`**: Use `"pretrained"` when non-target layers were frozen during fine-tuning. Use `"average"` for a compromise.
+
+## Implementation Details
+
+- [SuperposedAlgorithmBase][fusion_bench.method.randes.SuperposedAlgorithmBase]
+- [SuperposedModelSoupAlgorithm][fusion_bench.method.randes.SuperposedModelSoupAlgorithm]
+- [SuperposedTaskArithmeticAlgorithm][fusion_bench.method.randes.SuperposedTaskArithmeticAlgorithm]
+- [SuperposedTaskArithmeticLoRAAlgorithm][fusion_bench.method.randes.SuperposedTaskArithmeticLoRAAlgorithm]
+
+[^1]: (2024) Random Erasure Superposition for Compact Multi-Model Storage. The implementation follows the principles of randomized superposition for model compression and retrieval.

--- a/docs/algorithms/rankone_moe.md
+++ b/docs/algorithms/rankone_moe.md
@@ -1,0 +1,92 @@
+# RankOne MoE for Model Merging
+
+RankOne-MoE (Mixture of Experts) is a model merging approach that upscales merged models into a Mixture-of-Experts architecture. Instead of computing a single set of merged weights, it creates a pool of "experts" -- low-rank (rank-1) perturbations derived from each task-specific model -- and a learned router that dynamically selects which experts to use for each input.
+
+**The Rank-One Expert Construction**. For each task-specific model, the algorithm computes a rank-one decomposition of the task-specific weight update. Given a task model with weight $W_i$ and the pretrained weight $W_0$, the update $\Delta W_i = W_i - W_0$ is approximated by:
+
+$$\Delta W_i \approx a_i b_i^T$$
+
+where $a_i$ and $b_i$ are vectors. Each such rank-one pair $(a_i, b_i)$ forms an "expert" for that task at that layer.
+
+**Model Architecture**. The RankOne-MoE model replaces the MLP modules in each transformer layer with a `RankOneMoE` module. This module contains:
+- A **base model** (the merged model via task arithmetic, made non-trainable).
+- A **pool of experts** (rank-one perturbations, with `rank_k` experts per task).
+- A **router** (a small network with `router_hidden_layers` hidden layers) that scores each expert and selects the top-$k$.
+
+**The MoE Forward Pass**. For each input token, the router computes:
+
+$$\text{output} = f_{\text{base}}(x) + \sum_{e \in \text{top-}k} \text{softmax}(s_e(x)) \cdot e(x)$$
+
+where $s_e(x)$ is the router score for expert $e$ on input $x$, and $f_{\text{base}}$ is the base merged model.
+
+## Test-Time Adaptation
+
+After constructing the MoE model, the router parameters are fine-tuned via test-time adaptation. The optimization objective is **entropy maximization**:
+
+$$\mathcal{L} = -\mathbb{E}_x \left[ \sum_c p(c|x) \log p(c|x) \right]$$
+
+where $p(c|x)$ is the softmax probability of class $c$ given input $x$. Maximizing entropy encourages the router to produce confident, well-distributed predictions. The adaptation supports gradient accumulation across tasks (`use_grad_accumulate=true`) for memory efficiency.
+
+## Examples
+
+### CLI Usage
+
+```yaml title="config/method/rankone_moe/rankone_moe.yaml"
+--8<-- "config/method/rankone_moe/rankone_moe.yaml"
+```
+
+```bash
+fusion_bench \
+  method=rankone_moe/rankone_moe \
+  method.rank_k=32 \
+  method.select_k=-1 \
+  method.init_lambda=0.3 \
+  method.lr=0.0001 \
+  method.max_steps=1000 \
+  method.batch_size=16 \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `rank_k` | int | 32 | Number of rank-one experts added per task to the expert pool. |
+| `select_k` | int | -1 | Number of experts selected from the pool during inference. -1 means all experts. |
+| `init_lambda` | float | 0.3 | Scaling factor for the initial task arithmetic merge (base model). |
+| `lr` | float | 1e-4 | Learning rate for router test-time adaptation. |
+| `max_steps` | int | 1000 | Number of test-time adaptation steps. |
+| `batch_size` | int | 16 | Batch size for test-time adaptation. |
+| `num_workers` | int | 16 | DataLoader workers. |
+| `router_hidden_layers` | int | 1 | Number of hidden layers in the router network. |
+| `batch_reduce` | bool | true | Whether to use batch-reduce mode. Set to false for sample-wise adaptation at inference. |
+| `use_grad_accumulate` | bool | true | Use gradient accumulation across tasks to save memory. |
+| `svd_accelerator` | str | "cuda" | Device for SVD computation during expert construction. |
+| `checkpoint` | str/bool | False | Path to load a checkpoint (skips test-time adaptation). |
+| `save_checkpoint` | str/bool | False | Path to save a checkpoint after adaptation. |
+
+### API Usage
+
+```python
+from fusion_bench.method.rankone_moe import CLIPRankOneMoEAlgorithm
+
+# The algorithm is configured via DictConfig in the YAML
+# See config/method/rankone_moe/rankone_moe.yaml for the full config
+moe_model = algorithm.run(modelpool)
+
+# After construction, each layer's MLP is a RankOneMoE module
+# with learnable router parameters
+```
+
+## Output
+
+The algorithm returns a `RankOneMoE` model where each transformer layer's MLP has been replaced with a `RankOneMoE` module. The model supports both batch-reduced inference (all tasks processed together) and sample-wise inference (individual predictions).
+
+## Implementation Details
+
+- [fusion_bench.method.rankone_moe.rankone_moe.RankOneMoEAlgorithm][]
+- [fusion_bench.method.rankone_moe.clip_rankone_moe.CLIPRankOneMoEAlgorithm][]
+- [fusion_bench.models.rankone_moe.RankOneMoE][]
+
+[^1]: (2024) RankOne-MoE: Mixture of Experts for Multi-Task Model Merging. https://github.com/EnnengYang/RankOne-MoE

--- a/docs/algorithms/singular_value_calibration.md
+++ b/docs/algorithms/singular_value_calibration.md
@@ -1,0 +1,118 @@
+# Singular Value Calibration
+
+When merging multiple fine-tuned models, a fundamental challenge arises: parameters that encode shared knowledge across tasks get "over-counted" -- they are summed multiple times in the merged model, leading to spectral over-accumulation that degrades performance. Singular Value Calibration (SVC) addresses this by analyzing the merged model in the spectral domain and selectively scaling down subspaces where over-accumulation occurs.
+
+**The Core Problem**. Consider merging $K$ task-specific models via simple averaging or task arithmetic. For weight matrices, the merged weight can be expressed as:
+
+$$W_{\text{merge}} = W_{\text{pre}} + \frac{1}{K}\sum_{i=1}^{K} \Delta W_i$$
+
+where $W_{\text{pre}}$ is the pretrained base weight and $\Delta W_i = W_i - W_{\text{pre}}$ is the task-specific update. When multiple tasks update the same spectral subspace (e.g., the same singular direction), the merged response along that subspace becomes amplified, potentially distorting the shared representation.
+
+**Spectral Analysis via SVD**. SVC decomposes the merged update $\Delta W_{\text{merge}} = W_{\text{merge}} - W_{\text{pre}}$ using Singular Value Decomposition:
+
+$$\Delta W_{\text{merge}} = U \Sigma V^H$$
+
+Each left singular vector $u_r$ in $U$ defines a spectral subspace. The projection of each task's update onto this subspace yields a "subspace response":
+
+$$a_r^i = u_r^T \Delta W_i$$
+
+**Interference Measurement**. For each subspace $r$ and task $i$, SVC computes a projection coefficient that quantifies how the merged response scales along the task's direction:
+
+$$s_r^i = \frac{\langle a_r^{\text{merge}}, a_r^i \rangle}{\|a_r^i\|^2}$$
+
+When $s_r^i > 1$, the merged response amplifies that subspace relative to the task's original response, indicating over-counting. When $s_r^i < 1$, the response is attenuated.
+
+**Calibration**. SVC defines a per-subspace calibration factor:
+
+$$\gamma_r = \frac{K}{\sum_{i=1}^{K} \max(\alpha, s_r^i)}$$
+
+where $\alpha$ is a user-tunable hyperparameter that controls calibration strength. Higher $\alpha$ values lead to more aggressive calibration (greater scaling down), while lower values retain more of the original merged responses. The calibrated singular values are then:
+
+$$S_{\text{calibrated}} = \gamma \odot \Sigma$$
+
+and the calibrated merged weight is reconstructed as:
+
+$$W_{\text{calibrated}} = U \text{diag}(S_{\text{calibrated}}) V^H + W_{\text{pre}}$$
+
+## Implementation Details
+
+FusionBench provides three variants of SVC:
+
+1. **`SingularValueCalibration`** (`svc.py`): The base calibration algorithm. It requires a pre-merged model (with key `_merged_`) in the model pool. It iterates over all 2D weight matrices, performs SVD-based calibration, and updates the merged model in place. Both an original loop-based and an accelerated vectorized implementation are available (controlled via the `FUSION_BENCH_SVC_IMPL` environment variable).
+
+2. **`SingularValueCalibrationWithBaseMethod`** (`generic.py`): A generic wrapper that first runs an arbitrary base merging method (e.g., Simple Average, TIES-Merging, DARE) and then applies SVC calibration to the result. The base method is specified via the `base_method` config field.
+
+3. **`SingularValueCalibrationArithmeticTask`** (`task_arithmetic.py`): A convenience variant that combines Task Arithmetic with a configurable `scaling_factor` followed by SVC calibration.
+
+All variants operate layer-by-layer on 2D weight matrices only (biases and LayerNorm weights are left unchanged) and support GPU acceleration via the `accelerator` parameter.
+
+## Examples
+
+### CLI Usage -- SVC after Task Arithmetic
+
+```yaml title="config/method/singular_value_calibration/task_arithmetic.yaml"
+--8<-- "config/method/singular_value_calibration/task_arithmetic.yaml"
+```
+
+```bash
+fusion_bench \
+  method=singular_value_calibration/task_arithmetic \
+  method.scaling_factor=0.3 \
+  method.alpha=0.1 \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### CLI Usage -- SVC with Generic Base Method
+
+```yaml title="config/method/singular_value_calibration/simple_average.yaml"
+--8<-- "config/method/singular_value_calibration/simple_average.yaml"
+```
+
+```bash
+fusion_bench \
+  method=singular_value_calibration/simple_average \
+  method.alpha=0.1 \
+  method.base_method._target_=fusion_bench.method.SimpleAverageAlgorithm \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### API Usage
+
+```python
+import torch
+from fusion_bench.method.singular_value_calibration import SingularValueCalibration
+
+algorithm = SingularValueCalibration(alpha=0.1)
+
+# modelpool must contain '_merged_' (pre-merged model) and '_pretrained_'
+calibrated_model = algorithm.run(modelpool)
+```
+
+### Accelerated Implementation
+
+By default, the vectorized accelerated implementation is used. To use the original loop-based implementation:
+
+```bash
+FUSION_BENCH_SVC_IMPL=original fusion_bench method=singular_value_calibration/task_arithmetic ...
+```
+
+## Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `alpha` | float | 0.1 | Calibration strength. Higher values lead to more aggressive spectral scaling down. |
+| `accelerator` | str/None | None | Device for computation (e.g., `"cuda"`). Auto-detects if None. |
+| `scaling_factor` | float | 0.3 | (Arithmetic variant only) Scaling factor for task arithmetic before calibration. |
+| `base_method` | Dict | SimpleAverage | (Generic variant only) Config dict for the base merging algorithm. |
+
+## Implementation Details
+
+- [fusion_bench.method.singular_value_calibration.svc.SingularValueCalibration][]
+- [fusion_bench.method.singular_value_calibration.generic.SingularValueCalibrationWithBaseMethod][]
+- [fusion_bench.method.singular_value_calibration.task_arithmetic.SingularValueCalibrationArithmeticTask][]
+- [fusion_bench.method.singular_value_calibration.utils.subspace_consistency_spectral_calibration][]
+- [fusion_bench.method.singular_value_calibration.utils.subspace_consistency_spectral_calibration_accelerated][]
+
+[^1]: (2026) When Shared Knowledge Hurts: Spectral Over-Accumulation in Model Merging. http://arxiv.org/abs/2602.05536

--- a/docs/algorithms/sparselo_pruning.md
+++ b/docs/algorithms/sparselo_pruning.md
@@ -1,0 +1,149 @@
+# SparseLo Pruning
+
+SparseLo (LoSparse) is a structured pruning framework for Llama models that combines magnitude-based weight pruning with low-rank compensation. The core idea is to prune a large fraction of weights while compensating for the lost information by learning a low-rank decomposition of the pruned weights.
+
+**The LoSparse Linear Layer**. Each linear layer in the model is converted to a `LoSparseLinear` module, which consists of two parts:
+
+$$y = W_{\text{sparse}} x + B \cdot (A \cdot x)$$
+
+where:
+- $W_{\text{sparse}}$ is the pruned (sparse) weight matrix.
+- $B \in \mathbb{R}^{m \times r}$ and $A \in \mathbb{R}^{r \times n}$ form a low-rank (rank $r$) compensation matrix $B A^T$.
+
+The low-rank part captures the information lost during pruning, preserving model accuracy with minimal additional parameters.
+
+**Pruning Variants**. SparseLo supports multiple pruning strategies:
+
+1. **`wanda`**: Activation-aware pruning using the WANDA method. Importance scores are computed as $|w_i| \cdot \max_j |x_j|$ where $x_j$ are calibration activations.
+
+2. **`magnitude`**: Standard magnitude-based pruning using absolute weight values $|w_i|$ as importance scores.
+
+3. **`random`**: Random pruning as a baseline.
+
+4. **`lowrank-only`**: Extracts the low-rank part via SVD of the original weights and sets the sparse part to zero.
+
+5. **`dense`**: No pruning (debug mode).
+
+**Low-Rank Extraction**. After pruning, the low-rank compensation is extracted from the pruned weight matrix via SVD:
+
+$$W_{\text{pruned}} = U \Sigma V^T \implies A = V_k^T, \quad B = U_k \Sigma_k$$
+
+where $k = \text{rank}$. The sparse weight is then updated to $W_{\text{sparse}} = W_{\text{original}} - B A^T$.
+
+## Advanced Variants
+
+### PCP SparseLo (`PCPSparseLoForLlama`)
+
+The PCP (Principal Component Pursuit) variant applies an optimization-based refinement step after pruning. Given the original weight $W$ and the pruning mask, it solves:
+
+$$\min_q \ \|W \odot (1-m) + q \odot m\|_* + \lambda \|W \odot m - q \odot m\|_1$$
+
+where $\| \cdot \|$ denotes the nuclear norm and $\| \cdot \|_1$ is the entrywise L1 norm, $\lambda = 1/\sqrt{\max(|W|)}$, and $m$ is the pruning mask. This is optimized via Adam for `num_iterations` steps with cosine annealing. The refined sparse weights replace the magnitude-pruned ones.
+
+### Iterative SparseLo (`IterativeSparseLoForLlama`)
+
+The iterative variant progressively reconstructs the pruned weight matrix. For each iteration with increasing rank $r$:
+
+1. Compute the difference $W_{\text{diff}} = W_{\text{original}} - W_{\text{current}}$.
+2. Perform SVD of $W_{\text{diff}}$, retaining only the tail components (rank $r$ and above).
+3. Update: $W_{\text{current}} = W_{\text{current}} + \text{mask} \odots (U_{\text{tail}} \Sigma_{\text{tail}} V_{\text{tail}}^T)$.
+4. Stop early if the spectrum ratio (fraction of singular value energy in the first $r$ components) exceeds 0.99.
+
+This iterative reconstruction can optionally use a reference model's weights as the original.
+
+## Examples
+
+### CLI Usage -- Standard SparseLo
+
+```yaml title="config/method/sparselo_pruning/llama_sparselo.yaml"
+--8<-- "config/method/sparselo_pruning/llama_sparselo.yaml"
+```
+
+```bash
+fusion_bench \
+  method=sparselo_pruning/llama_sparselo \
+  method.rank=128 \
+  method.sparsity_ratio=0.5 \
+  method.prune_type=unstructured \
+  method.variant=wanda \
+  method.nsamples=128 \
+  modelpool=CausalLMPool/meta-llama/Llama-2-7b-hf
+```
+
+### CLI Usage -- Iterative SparseLo
+
+```yaml title="config/method/sparselo_pruning/llama_iterative_sparselo.yaml"
+--8<-- "config/method/sparselo_pruning/llama_iterative_sparselo.yaml"
+```
+
+```bash
+fusion_bench \
+  method=sparselo_pruning/llama_iterative_sparselo \
+  method.rank=128 \
+  method.num_iterations=10 \
+  method.sparsity_ratio=0.5 \
+  method.variant=wanda \
+  method.use_reference_model=false \
+  modelpool=CausalLMPool/meta-llama/Llama-2-7b-hf
+```
+
+### CLI Usage -- PCP SparseLo
+
+```yaml title="config/method/sparselo_pruning/llama_pcp_sparselo.yaml"
+--8<-- "config/method/sparselo_pruning/llama_pcp_sparselo.yaml"
+```
+
+```bash
+fusion_bench \
+  method=sparselo_pruning/llama_pcp_sparselo \
+  method.rank=128 \
+  method.num_iterations=10 \
+  method.sparsity_ratio=0.5 \
+  method.variant=wanda \
+  modelpool=CausalLMPool/meta-llama/Llama-2-7b-hf
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `rank` | int | 128 | Rank of the low-rank compensation matrix. |
+| `variant` | str | "wanda" | Pruning variant: "dense", "random", "wanda", "lowrank-only", "magnitude". |
+| `nsamples` | int | 128 | Number of calibration samples (for wanda variant). |
+| `sparsity_ratio` | float | 0.5 | Fraction of weights to prune (unstructured). |
+| `prune_type` | str | "unstructured" | "unstructured" or "semistructured". |
+| `n`, `m` | int | 2, 4 | n:m ratio for semistructured pruning. |
+| `num_iterations` | int | 10 | (Iterative/PCP only) Number of refinement iterations. |
+| `use_reference_model` | bool | false | (Iterative only) Use a reference model's weights. |
+| `model_save_path` | str | null | Path to save the pruned model. |
+
+### API Usage
+
+```python
+from fusion_bench.method.sparselo.sparselo import SparseLoForLlama
+
+algorithm = SparseLoForLlama(
+    nsamples=128,
+    variant="wanda",
+    seed=0,
+    rank=128,
+    sparsity_ratio=0.5,
+    prune_type="unstructured",
+    n=2,
+    m=4,
+)
+pruned_model = algorithm.run(modelpool)
+```
+
+## Model Conversion
+
+The algorithm converts a standard `LlamaForCausalLM` to a `LoSparseLlamaForCausalLM` by replacing all `nn.Linear` modules with `LoSparseLinear` modules. Each `LoSparseLinear` layer has three weight matrices: `weight` (sparse), `lo_A`, and `lo_B` (low-rank).
+
+## Implementation Details
+
+- [fusion_bench.method.sparselo.sparselo.SparseLoForLlama][]
+- [fusion_bench.method.sparselo.sparselo.PCPSparseLoForLlama][]
+- [fusion_bench.method.sparselo.sparselo.IterativeSparseLoForLlama][]
+- [fusion_bench.models.modeling_losparse_llama.losparse_linear.LoSparseLinear][]
+
+[^1]: SparseLo: Sparse Models with Low-Rank Compensation for Efficient Language Model Compression.

--- a/docs/algorithms/surgery.md
+++ b/docs/algorithms/surgery.md
@@ -1,0 +1,73 @@
+# Surgery for Model Merging
+
+After merging multiple task-specific models, the merged model often exhibits a representation gap: the internal features it produces for task-specific inputs differ from what the individual fine-tuned models would produce. Surgery addresses this by optimizing a set of learnable blending parameters that adjust the merged model's feature representations to better align with the original task-specific models.
+
+**The Core Idea**. Traditional merging methods (e.g., AdaMerging, Task Arithmetic) operate in the weight space, computing a single set of merged weights. However, optimal merging may require different interpolation strategies at the representation level. Surgery introduces learnable alpha parameters that reweight the contributions of each expert model when computing features, and these alphas are optimized via gradient descent to minimize the L1 distance between the merged model's features and the target fine-tuned model's features.
+
+**The Surgery Model Wrapper**. The algorithm wraps the merged model in a `SurgeryModelWrapper` that introduces learnable parameters per layer and per task. For each input sample from task $t$, the wrapper computes features as a weighted combination of features from each expert model and the merged model:
+
+$$h_{\text{surgery}}(x_t) = \sum_{i} \alpha_i^{(t)} \cdot h_i(x_t)$$
+
+where $h_i(x_t)$ is the feature produced by the $i$-th expert model on input $x_t$ from task $t$, and $\alpha_i^{(t)}$ are the learnable surgery parameters.
+
+**Optimization**. The surgery parameters are optimized to minimize the feature-level reconstruction loss:
+
+$$\mathcal{L} = \| h_{\text{surgery}}(x_t) - h_{\text{target}}(x_t) \|_1$$
+
+where $h_{\text{target}}(x_t)$ is the feature produced by the fine-tuned model for task $t$. The optimization runs for `surgery_steps` iterations using the Adam optimizer with a fixed learning rate of $10^{-3}$.
+
+## Two-Phase Pipeline
+
+The Surgery implementation in FusionBench follows a two-phase approach:
+
+1. **AdaMerging Phase**: First, layer-wise AdaMerging is performed to obtain initial merge weights via test-time adaptation. This produces a statically merged model.
+
+2. **Surgery Phase**: The merged model is then wrapped in a `SurgeryModelWrapper`, and the learnable alpha parameters are optimized over task-specific calibration data to reduce the representation gap.
+
+## Examples
+
+### CLI Usage
+
+```yaml title="config/method/surgery/adamerging_surgery.yaml"
+--8<-- "config/method/surgery/adamerging_surgery.yaml"
+```
+
+```bash
+fusion_bench \
+  method=surgery/adamerging_surgery \
+  method.surgery_steps=1000 \
+  method.eval_iterations=200 \
+  method.max_steps=1000 \
+  method.lr=0.001 \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `surgery_steps` | int | 1000 | Number of gradient descent steps for surgery optimization. |
+| `eval_iterations` | int | 200 | Frequency of evaluation during surgery training. |
+| `max_steps` | int | 1000 | Max steps for the initial AdaMerging test-time adaptation. |
+| `lr` | float | 1e-3 | Learning rate for the surgery Adam optimizer. |
+| `batch_size` | int | 16 | Batch size for calibration data during both phases. |
+| `num_workers` | int | 8 | Number of DataLoader workers. |
+| `weights` | str/None | null | Path to pre-computed merge weights. If set, skips test-time adaptation. |
+| `clamp_weights` | bool | false | Whether to clamp AdaMerging weights to [0, 1]. |
+| `save_merging_weights` | str | 'merging_weights.pt' | Path to save the AdaMerging merge weights. |
+
+## Output
+
+The algorithm returns a dictionary with two keys:
+
+- `"adamerging"`: The statically merged model from the AdaMerging phase.
+- `"surgery"`: The SurgeryModelWrapper with learnable alpha parameters.
+
+## Implementation Details
+
+- [fusion_bench.method.surgery.clip_layer_wise_adamerging_surgery.CLIPLayerWiseAdaMergingSurgeryAlgorithm][]
+- [fusion_bench.models.surgery.surgerymodelwrapper.SurgeryModelWrapper][]
+
+[^1]: (ICLR 2024) AdaMerging: Adaptive Model Merging for Multi-Task Learning. http://arxiv.org/abs/2310.02575
+[^2]: (ICML 2024) Representation Surgery for Multi-Task Model Merging. http://arxiv.org/abs/2402.02705

--- a/docs/algorithms/tall_mask.md
+++ b/docs/algorithms/tall_mask.md
@@ -1,0 +1,89 @@
+# Tall Mask for Model Merging
+
+Tall Mask is a parameter-efficient retrieval-based approach to model merging. Instead of producing a single merged model, Tall Mask generates task-specific binary masks that selectively retrieve parameters from a merged model. The key insight is that not all parameters in a merged model are useful for every task -- some parameters encode task-specific knowledge that conflicts with others. By applying a task-specific mask, each task can retrieve only the parameters that benefit it.
+
+**The Mask Generation Rule**. Given a pretrained model with parameters $\theta_0$, a merged multi-task model with parameters $\theta_{mt}$, and a task-specific fine-tuned model with parameters $\theta_t$, the Tall Mask for task $t$ is defined as:
+
+$$\text{mask}_t = \mathbb{I}\left( \|\theta_0 - \theta_t\|_1 > \lambda \cdot \|\theta_{mt} - \theta_t\|_1 \right)$$
+
+where $\lambda$ (the `tall_mask_lambda` hyperparameter) controls the selectivity of the mask. Intuitively, this rule says: "keep a parameter for task $t$ if the pretrained model is farther from the task-specific model than the merged model is (up to a scaling factor $\lambda$)."
+
+When $\lambda = 1.0$, the mask is strict -- only parameters where the merged model is genuinely closer to the task-specific model are retained. When $\lambda < 1.0$, the mask is more permissive. When $\lambda > 1.0$, the mask is more restrictive.
+
+**Model Retrieval**. Once the Tall Mask is computed, the retrieved model for task $t$ is:
+
+$$\theta_t^{\text{retrieved}} = \theta_0 + \text{mask}_t \odot (\theta_{mt} - \theta_0)$$
+
+This effectively starts from the pretrained model and overlays only the task-relevant portions of the merged update vector.
+
+## Multi-Task Vector Computation
+
+The multi-task vector is computed as the sum of individual task vectors:
+
+$$\tau_{\text{multi}} = \sum_{i} \tau_i = \sum_{i} (\theta_i - \theta_0)$$
+
+The merged model parameters are then:
+
+$$\theta_{mt} = \theta_0 + \tau_{\text{multi}}$$
+
+This is equivalent to the Task Arithmetic merge (with scaling factor $\lambda = 1$).
+
+## Examples
+
+### CLI Usage
+
+```yaml title="config/method/tall_mask/task_arithmetic.yaml"
+--8<-- "config/method/tall_mask/task_arithmetic.yaml"
+```
+
+```bash
+fusion_bench \
+  method=tall_mask/task_arithmetic \
+  method.tall_mask_lambda=0.6 \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tall_mask_lambda` | float | 0.6 | Threshold scaling factor for mask generation. Lower values produce more permissive masks. |
+| `debug` | int | 0 | Debug level. |
+| `verbose` | int | 0 | Verbosity level. |
+
+### API Usage
+
+```python
+from fusion_bench.method.tall_mask import TallMaskTaskArithmeticAlgorithm
+
+algorithm = TallMaskTaskArithmeticAlgorithm(tall_mask_lambda=0.6)
+result = algorithm.run(modelpool)
+# result["models"] is a dict mapping task name -> retrieved model
+```
+
+## Output
+
+The algorithm returns a dictionary with two keys:
+
+- `"models"`: A dict mapping each task name to its retrieved model (pretrained model with the Tall Mask applied).
+- `"metadata"`: Additional metadata (currently None).
+
+Each retrieved model is a deep copy of the pretrained model with selectively applied merged parameters.
+
+## Utility Functions
+
+The `utils.py` module provides additional helper functions for advanced use cases:
+
+- **`construct_tall_mask`**: Generates Tall Masks for multiple lambda values (0.2 through 0.6).
+- **`find_optimal_mask`**: Selects the best lambda per task based on validation accuracy.
+- **`construct_consensus_mask`**: Builds a consensus mask by counting activation frequency across tasks, enabling parameter pruning.
+
+## Implementation Details
+
+- [fusion_bench.method.tall_mask.task_arithmetic.TallMaskTaskArithmeticAlgorithm][]
+- [fusion_bench.method.tall_mask.task_arithmetic.generate_task_masks][]
+- [fusion_bench.method.tall_mask.utils.generate_task_masks][]
+
+[^1]: Original implementation from: https://github.com/nik-dim/tall_masks/
+[^2]: Adopted into FusionBench from: https://github.com/Zhou-Hangyu/randes/

--- a/docs/algorithms/trust_region.md
+++ b/docs/algorithms/trust_region.md
@@ -1,0 +1,100 @@
+# Trust Region for Model Merging
+
+Trust Region is a training-free model merging approach that identifies and navigates knowledge conflicts between task vectors. The core idea is to construct a "trust region" mask that identifies parameter dimensions where tasks conflict with each other, then zero out the conflicting portions of each task vector before merging.
+
+**The Conflict Metric**. For each pair of tasks $(i, j)$, the algorithm computes a conflict measure:
+
+$$\Omega = \sum_{i \neq j} |\bar{g}_i| \odot |\tau_j|$$
+
+where $\bar{g}_i$ is the average absolute gradient for task $i$ (computed on its training data), $\tau_j$ is the task vector for task $j$, and $\odot$ denotes element-wise multiplication. The matrix $\Omega$ is a flattened vector where each element represents the cumulative conflict across all task pairs at that parameter dimension.
+
+**Trust Region Mask**. A threshold is applied to $\Omega$ to create a binary mask:
+
+$$\text{mask} = \mathbb{I}(\Omega < \text{threshold})$$
+
+The threshold is set to the $q$-th quantile of $\Omega$ values (controlled by `threshold_quantile`). Parameters with conflict values below the threshold are considered "safe" and are preserved; parameters above the threshold are deemed conflicting and are zeroed out.
+
+**Task Vector Masking**. Each task vector is masked:
+
+$$\tau_i^{\text{masked}} = \tau_i \odot \text{mask}$$
+
+Then the masked task vectors are summed and added to the pretrained model:
+
+$$\theta = \theta_0 + \lambda \sum_i \tau_i^{\text{masked}}$$
+
+**Gradient Computation**. The average absolute gradient for each task is computed by:
+1. Taking the pretrained model (initialized from scratch for each task)
+2. Computing per-sample gradients on the task's training data (up to `max_samples` samples)
+3. Averaging the absolute gradient values across all samples
+
+In zero-shot mode (`zero_shot=true`), the task vector's absolute values are used as a proxy for gradients, eliminating the need for training data.
+
+## Examples
+
+### CLI Usage
+
+```yaml title="config/method/trust_region/clip_task_arithmetic.yaml"
+--8<-- "config/method/trust_region/clip_task_arithmetic.yaml"
+```
+
+```bash
+fusion_bench \
+  method=trust_region/clip_task_arithmetic \
+  method.scaling_factor=0.3 \
+  method.threshold_quantile=0.99 \
+  method.max_samples=128 \
+  method.batch_size=128 \
+  method.zero_shot=false \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### Zero-Shot Mode
+
+When training data is unavailable, use zero-shot mode which substitutes gradients with task vector magnitudes:
+
+```bash
+fusion_bench \
+  method=trust_region/clip_task_arithmetic \
+  method.zero_shot=true \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `scaling_factor` | float or list[float] | 0.3 | Scaling factor for the merged task vector. Can be a single value (returns one model) or a list (returns a dict of models). |
+| `threshold_quantile` | float | 0.99 | Quantile of the conflict metric used as the trust region threshold. Lower values are more aggressive. |
+| `max_samples` | int | 128 | Maximum number of training samples per task for gradient computation. |
+| `batch_size` | int | 128 | Batch size for gradient computation. |
+| `zero_shot` | bool | false | If true, use task vector abs as gradient proxy instead of computing actual gradients. |
+
+### API Usage
+
+```python
+from fusion_bench.method.trust_region import TaskArithmeticWithTrustRegionForCLIP
+
+algorithm = TaskArithmeticWithTrustRegionForCLIP(
+    scaling_factor=0.3,
+    threshold_quantile=0.99,
+    max_samples=128,
+    batch_size=128,
+    zero_shot=False,
+)
+merged_model = algorithm.run(modelpool)
+```
+
+## Output
+
+- When `scaling_factor` is a single float: returns the merged model directly.
+- When `scaling_factor` is a list of floats: returns a dict mapping each scaling factor to its merged model, enabling hyperparameter search.
+
+## Implementation Details
+
+- [fusion_bench.method.trust_region.clip_task_arithmetic.TaskArithmeticWithTrustRegionForCLIP][]
+- [fusion_bench.method.trust_region.utils.state_dict_to_vector][]
+- [fusion_bench.method.trust_region.utils.vector_to_state_dict][]
+
+[^1]: (2024) Task Arithmetic in Trust Region: A Training-Free Model Merging Approach to Navigate Knowledge Conflicts. https://openreview.net/forum?id=q3ztjJRQuJ

--- a/docs/api/fusion_bench.method/ensemble.md
+++ b/docs/api/fusion_bench.method/ensemble.md
@@ -8,3 +8,5 @@
         - SimpleEnsembleAlgorithm
         - WeightedEnsembleAlgorithm
         - MaxModelPredictorAlgorithm
+        - DataAdaptiveWeightEnsemblingForCLIP
+        - FlanT5WeightEnsemblingMoEAlgorithm

--- a/docs/api/fusion_bench.method/merging.md
+++ b/docs/api/fusion_bench.method/merging.md
@@ -15,6 +15,7 @@
         members:
         - SimpleAverageAlgorithm
         - SimpleAverageForLlama
+        - SimpleAverageForCausalLM
 
 ### Weighted Average
 
@@ -46,6 +47,7 @@
         members:
         - TaskArithmeticAlgorithm
         - TaskArithmeticForLlama
+        - TaskArithmeticForCausalLM
 
 ### Ties-Merging
 
@@ -55,6 +57,7 @@
         heading_level: 4
         members:
         - TiesMergingAlgorithm
+        - TiesMergingForCausalLM
 
 ### Fisher Merging
 
@@ -108,6 +111,8 @@
         - CLIPLayerWiseAdaMergingAlgorithm
         - GPT2LayerWiseAdaMergingAlgorithm
         - FlanT5LayerWiseAdaMergingAlgorithm
+        - ResNetLayerWiseAdamerging
+        - ResNetTaskWiseAdamerging
 
 
 ## Optimization-based Methods
@@ -163,6 +168,10 @@
         - ConcreteTaskArithmeticAlgorithmForCLIP
         - ConcreteTaskWiseAdaMergingForCLIP
         - ConcreteLayerWiseAdaMergingForCLIP
+        - ConcreteSafeLayerWiseAdaMergingForCLIP
+        - ConcreteSafeTaskWiseAdaMergingForCLIP
+        - PostDefenseAWMAlgorithmForCLIP
+        - PostDefenseSAUAlgorithmForCLIP
 
 ### Task Singular Vector Merging (TSVM)
 
@@ -172,6 +181,33 @@
         heading_level: 4
         members:
         - TaskSingularVectorMerging
+
+### AdaSVD
+
+::: fusion_bench.method
+    options:
+        show_root_heading: false
+        heading_level: 4
+        members:
+        - AdaSVDMergingForCLIPVisionModel
+
+### Model Stock
+
+::: fusion_bench.method
+    options:
+        show_root_heading: false
+        heading_level: 4
+        members:
+        - ModelStock
+
+### Tall Mask
+
+::: fusion_bench.method
+    options:
+        show_root_heading: false
+        heading_level: 4
+        members:
+        - TallMaskTaskArithmeticAlgorithm
 
 ### Isotropic Merging
 

--- a/docs/api/fusion_bench.method/mixing.md
+++ b/docs/api/fusion_bench.method/mixing.md
@@ -21,15 +21,6 @@
         members:
         - ModelRecombinationAlgorithm
 
-::: fusion_bench.method.model_recombination
-    options:
-        show_root_heading: false
-        heading_level: 4
-        members:
-        - recombine_modellist
-        - recombine_modeldict
-        - recombine_state_dict
-
 ## MoE-based Mixing
 
 ### MoE Upscaling
@@ -80,7 +71,6 @@
         show_root_heading: false
         heading_level: 4
         members:
-        - PWEMoEAlgorithmForCLIP
         - PWEMoELinearScalarizationForCLIP
         - PWEMoExactParetoOptimalForCLIP
 

--- a/docs/api/fusion_bench.method/training.md
+++ b/docs/api/fusion_bench.method/training.md
@@ -8,9 +8,12 @@
 ::: fusion_bench.method
     options:
         show_root_heading: false
+        heading_level: 4
         members:
-            - ImageClassificationFineTuningForCLIP
-            - ContinualImageClassificationFineTuningForCLIP
+        - ImageClassificationFineTuning
+        - ImageClassificationFineTuning_Test
+        - ImageClassificationFineTuningForCLIP
+        - ContinualImageClassificationFineTuningForCLIP
 
 
 ## LLM Fine-tuning
@@ -29,3 +32,11 @@
         show_root_heading: false
         members:
         - BradleyTerryRewardModeling
+
+## LLM Fine-tuning with AdaMerging
+
+::: fusion_bench.method
+    options:
+        show_root_heading: false
+        members:
+        - LayerWiseAdaMergingForLlamaSFT

--- a/docs/api/fusion_bench.method/utility.md
+++ b/docs/api/fusion_bench.method/utility.md
@@ -6,6 +6,16 @@
 
 ::: fusion_bench.method.DummyAlgorithm
 
+## Base Algorithm Classes
+
+::: fusion_bench.method
+    options:
+        show_root_heading: false
+        heading_level: 3
+        members:
+        - BaseAlgorithm
+        - BaseModelFusionAlgorithm
+
 ## Analysis Purpose
 
 - [TaskVectorCosSimilarity][fusion_bench.method.TaskVectorCosSimilarity]: Computes the cosine similarity between task vectors.

--- a/docs/api/fusion_bench.modelpool.md
+++ b/docs/api/fusion_bench.modelpool.md
@@ -2,27 +2,43 @@
 
 ## Base Class
 
-::: fusion_bench.BaseModelPool
+### BaseModelPool
 
-## Vision Model Pool
-
-### NYUv2 Tasks (ResNet)
-
-::: fusion_bench.modelpool.NYUv2ModelPool
+::: fusion_bench.modelpool
     options:
+        show_root_heading: false
         heading_level: 4
+        members:
+        - BaseModelPool
+
+## Vision Model Pools
 
 ### CLIP Vision Encoder
 
-::: fusion_bench.modelpool.CLIPVisionModelPool
+::: fusion_bench.modelpool
     options:
+        show_root_heading: false
         heading_level: 4
+        members:
+        - CLIPVisionModelPool
 
 ### OpenCLIP Vision Encoder
 
-::: fusion_bench.modelpool.OpenCLIPVisionModelPool
+::: fusion_bench.modelpool
     options:
+        show_root_heading: false
         heading_level: 4
+        members:
+        - OpenCLIPVisionModelPool
+
+### NYUv2 Model Pool
+
+::: fusion_bench.modelpool
+    options:
+        show_root_heading: false
+        heading_level: 4
+        members:
+        - NYUv2ModelPool
 
 ### ResNet for Image Classification
 
@@ -55,9 +71,9 @@
         - load_transformers_dinov2
         - Dinov2ForImageClassificationPool
 
-## NLP Model Pool
+## NLP Model Pools
 
-### GPT-2
+### GPT-2 for Sequence Classification
 
 ::: fusion_bench.modelpool
     options:
@@ -67,7 +83,7 @@
         - HuggingFaceGPT2ClassificationPool
         - GPT2ForSequenceClassificationPool
 
-## Seq2Seq Language Models (Flan-T5)
+### Seq2Seq Language Models (Flan-T5)
 
 ::: fusion_bench.modelpool
     options:
@@ -75,10 +91,18 @@
         heading_level: 4
         members:
         - Seq2SeqLMPool
-        - SequenceClassificationModelPool
         - PeftModelForSeq2SeqLMPool
 
-## Causal Language Models (Llama, Mistral, Qwen...)
+### Sequence Classification Language Models
+
+::: fusion_bench.modelpool
+    options:
+        show_root_heading: false
+        heading_level: 4
+        members:
+        - SequenceClassificationModelPool
+
+### Causal Language Models (Llama, Mistral, Qwen...)
 
 ::: fusion_bench.modelpool
     options:
@@ -92,7 +116,7 @@
     options:
         heading_level: 4
 
-## Others
+## Generic Model Pools
 
 ### Transformers AutoModel
 

--- a/docs/api/fusion_bench.optim.md
+++ b/docs/api/fusion_bench.optim.md
@@ -1,5 +1,8 @@
-# fusion_bench.optim
+# Optim
 
-## MeZO optimizer
+Custom optimizers and optimizer utilities for model fusion.
 
-::: fusion_bench.optim.MeZO
+::: fusion_bench.optim
+    options:
+      show_source: false
+      show_submodules: true

--- a/docs/api/fusion_bench.taskpool.md
+++ b/docs/api/fusion_bench.taskpool.md
@@ -23,6 +23,15 @@
         - SparseWEMoECLIPVisionModelTaskPool
         - RankoneMoECLIPVisionModelTaskPool
 
+### OpenCLIP Vision Tasks
+
+::: fusion_bench.taskpool
+    options:
+        heading_level: 4
+        show_root_heading: false
+        members:
+        - OpenCLIPVisionModelTaskPool
+
 ### ResNet for Image Classification
 
 ::: fusion_bench.taskpool
@@ -37,6 +46,12 @@
 ### GPT-2
 
 ::: fusion_bench.taskpool.GPT2TextClassificationTaskPool
+    options:
+        heading_level: 4
+
+### Llama
+
+::: fusion_bench.taskpool.LlamaTestGenerationTaskPool
     options:
         heading_level: 4
 

--- a/docs/api/fusion_bench.utils/misc.md
+++ b/docs/api/fusion_bench.utils/misc.md
@@ -1,0 +1,5 @@
+# Misc Utilities
+
+::: fusion_bench.utils.misc
+    options:
+      show_source: false

--- a/docs/cli/fusion_bench.md
+++ b/docs/cli/fusion_bench.md
@@ -5,7 +5,7 @@ It provides a flexible way to configure and execute various fusion algorithms on
 
 ## Details and Options
 
-`fusion_bench` takes a configuration file as input, which specifies the models, fusion method to be used, and the datasets to be evaluated. running `fusion_bench` is equivalent to running `python fusion_bench/scripts/cli.py`.
+`fusion_bench` takes a configuration file as input, which specifies the models, fusion method to be used, and the datasets to be evaluated. Running `fusion_bench` is equivalent to running `python fusion_bench/scripts/cli.py`.
 
 ```bash
 fusion_bench [--config-path CONFIG_PATH] [--config-name CONFIG_NAME] \
@@ -16,9 +16,23 @@ python fusion_bench/scripts/cli.py [--config-path CONFIG_PATH] [--config-name CO
     OPTION_1=VALUE_1 OPTION_2=VALUE_2 ...
 ```
 
-`fusion_bench` has the following options, `method`, `modelpool`, and `taskpool` are the most important ones among these options:
+The entry point is defined in `fusion_bench/scripts/cli.py` using Hydra's `@hydra.main` decorator. The default config path is `config/` and the default config name is `fabric_model_fusion.yaml`.
 
-### Hydra options
+```python
+@hydra.main(
+    config_path=get_default_config_path(),
+    config_name="fabric_model_fusion",
+    version_base=None,
+)
+def _hydra_main(cfg: DictConfig) -> None:
+    main(cfg)
+```
+
+The `main()` function resolves config interpolations, instantiates the program via `fusion_bench.utils.instantiate`, and calls `program.run()`.
+
+## Hydra Options
+
+### Help and Info
 
 - **--help, -h**: Application's help. Print help message and exit.
 
@@ -28,177 +42,335 @@ python fusion_bench/scripts/cli.py [--config-path CONFIG_PATH] [--config-name CO
 
 - **--hydra-help**: Hydra's help.
 - **--version**: Show Hydra's version and exit.
-- **--cfg, -c**: Show config instead of running [job|hydra|all].
-  This is useful for debugging the configuration. However, this just prints plain text configuration without color highlighting or formatting.
+- **--info, -i**: Print Hydra information. Accepts: `all`, `config`, `defaults`, `defaults-tree`, `plugins`, `searchpath`.
 
   ```bash
-  fusion_bench --cfg
+  fusion_bench --info defaults-tree
   ```
 
-  Or equivalently with the following options:
+### Configuration Inspection
+
+- **--cfg, -c**: Show config instead of running. Accepts: `job`, `hydra`, or `all` (default).
+  This prints plain text configuration without color highlighting.
 
   ```bash
-  # this will print the configuration using rich library, which provides syntax highlighting and better formatting
+  fusion_bench --cfg job
+  ```
+
+  For a beautifully formatted output with syntax highlighting, use:
+
+  ```bash
   fusion_bench print_config=true dry_run=true
   ```
 
-- **--resolve**: Used in conjunction with --cfg, resolve config interpolations before printing.
-- **--package, -p**: Config package to show. For example, when you only want to see the configuration for `method`.
+- **--resolve**: Used in conjunction with `--cfg`, resolves config interpolations (e.g., `${path.data_dir}`) before printing.
+
+  ```bash
+  fusion_bench --cfg job --resolve
+  ```
+
+- **--package, -p**: Config package to show. For example, when you only want to see the configuration for `method`:
 
   ```bash
   fusion_bench --cfg job -p method
   ```
 
-- **--info, -i**: Print Hydra information [all|config|defaults|defaults-tree|plugins|searchpath]
-- **--config-path, -cp**: Overrides the config_path specified in hydra.main(). The config_path is absolute or relative to the Python file declaring @hydra.main().
-By default, the config path is the `config` or `fusion_bench_config` directory in the project root.
-- **--config-name, -cn**: Overrides the config_name specified in hydra.main(). By default, the config name is `example_config` so `config/example_config.yaml` will be loaded.
-You can also specify another config name, for example:
+### Config Path Overrides
+
+- **--config-path, -cp**: Overrides the `config_path` specified in `@hydra.main()`. The path is absolute or relative to the Python file declaring the decorator (i.e., `fusion_bench/scripts/cli.py`).
+  By default, the config path is the `config` directory in the project root.
 
   ```bash
-  # this will load the config from `config/llama_weighted_average.yaml`
-  fusion_bench --config-name llama_weighted_average.yaml
+  fusion_bench --config-path /path/to/custom/configs method=my_method
   ```
 
-- **--config-dir, -cd**: Adds an additional config dir to the config search path
-- **--multirun, -m**: Run multiple jobs with the configured launcher and sweeper. For more information, see [Hydra documentation](https://hydra.cc/docs/1.3/tutorials/basic/running_your_app/multi-run/).
-- **--experimental-rerun**: Rerun a job from a previous config pickle
+- **--config-name, -cn**: Overrides the `config_name` specified in `@hydra.main()`. By default, the config name is `fabric_model_fusion` so `config/fabric_model_fusion.yaml` is loaded.
 
-#### Shell Completion
+  ```bash
+  fusion_bench --config-name custom_config.yaml
+  ```
 
-This is useful for tab completion in the shell. You can install shell completion for Bash, Fish, and Zsh.
+- **--config-dir, -cd**: Adds an additional config directory to the config search path.
 
-<figure markdown="span">
-![alt text](images/tab_completion.png){ width="850" }
-<figcaption> Screenshot of tab completion in the shell. </figcaption>
-</figure>
+  ```bash
+  fusion_bench --config-dir ./my_configs method=my_method modelpool=my_models
+  ```
 
-- **--shell-completion, -sc**: Install or Uninstall shell completion:
-  - **Bash - Install**:
+### Multi-Run and Sweeps
 
-    ```bash
-    eval "$(fusion_bench -sc install=bash)"
-    ```
+- **--multirun, -m**: Run multiple jobs with the configured launcher and sweeper. This is the primary way to run hyperparameter sweeps or compare multiple configurations in a single command.
 
-  - **Bash - Uninstall**:
+  See [Hydra multi-run documentation](https://hydra.cc/docs/1.3/tutorials/basic/running_your_app/multi-run/) for details.
 
-    ```bash
-    eval "$(fusion_bench -sc uninstall=bash)"
-    ```
+  ```bash
+  # Sweep scaling_factor across values
+  fusion_bench -m \
+    method=task_arithmetic \
+    method.scaling_factor=0.1,0.3,0.5,1.0 \
+    modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+    taskpool=dummy
 
-  - **Fish - Install**:
+  # Sweep across methods
+  fusion_bench -m \
+    method=task_arithmetic,simple_average \
+    modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+    taskpool=dummy
+  ```
 
-    ```fish
-    fusion_bench -sc install=fish | source
-    ```
+- **--experimental-rerun**: Rerun a job from a previous config pickle.
 
-  - **Fish - Uninstall**:
+### Shell Completion
 
-    ```fish
-    fusion_bench -sc uninstall=fish | source
-    ```
+Install shell completion for tab-completing arguments:
 
-  - **Zsh - Install**:
-    Zsh is compatible with the Bash shell completion, see the [documentation](https://hydra.cc/docs/1.2/tutorials/basic/running_your_app/tab_completion#zsh-instructions) for details.
+- **Bash - Install**:
 
-    ```zsh
-    eval "$(fusion_bench -sc install=bash)"
-    ```
+  ```bash
+  eval "$(fusion_bench -sc install=bash)"
+  ```
 
-  - **Zsh - Uninstall**:
+- **Bash - Uninstall**:
 
-    ```zsh
-    eval "$(fusion_bench -sc uninstall=bash)"
-    ```
+  ```bash
+  eval "$(fusion_bench -sc uninstall=bash)"
+  ```
 
-### Application Options
+- **Fish - Install**:
 
-- **report_save_path**: The path to save the report. If not specified or is `false`, the report will not be saved. The report will be saved as a JSON file. Default is `false`.
-    For example, to save the report to `outputs/report.json`:
+  ```fish
+  fusion_bench -sc install=fish | source
+  ```
 
-    ```bash
-    fusion_bench report_save_path=outputs/report.json
-    ```
+- **Fish - Uninstall**:
 
-- **print_config**: Whether to print the configuration to the console. If not specified or is `false`, the configuration will not be printed. Default is `true`.
-    For example, to print the configuration:
+  ```fish
+  fusion_bench -sc uninstall=fish | source
+  ```
 
-    ```bash
-    fusion_bench print_config=true
-    ```
+- **Zsh - Install/Uninstall**: Compatible with Bash shell completion.
 
-- **dry_run**: Perform a dry run.
-    This will only validate the configuration without running the actual code. Default is `false`.
-    For example, to perform a dry run and print the configuration:
+  ```zsh
+  eval "$(fusion_bench -sc install=bash)"
+  ```
 
-    ```bash
-    fusion_bench dry_run=true print_config=true
-    ```
+## Application Options
 
-- **merged_model_save_path**: The path to save the merged model. If specified, the merged model will be saved to this path by calling `modelpool.save_model`.
-    For example, to save the merged model to `outputs/merged_model.pt`:
+These options are defined in the main configuration file (`config/fabric_model_fusion.yaml`) and can be overridden from the command line.
 
-    ```bash
-    fusion_bench merged_model_save_path=outputs/merged_model.pt
-    ```
+### Execution Control
 
-    Note that the behavior of `modelpool.save_model` depends on the implementation of the model pool. Take `AutoModelForCausalLMPool` as an example, it will save the model to the specified path as a directory containing the model configuration and safetensor files, i.e., calling `model.save_pretrained(merged_model_save_path)`.
+- **dry_run**: Perform a dry run. Validates the configuration without running the actual fusion code. Default is `false`.
 
-    ??? example "Example of `modelpool.save_model`"
+  ```bash
+  fusion_bench dry_run=true print_config=true
+  ```
 
-        `ModelPool` is the base class for model pools. The `save_model` method is defined in the `ModelPool` class and can be overridden in the derived classes. For example, `AutoModelForCausalLMPool` overrides the `save_model` method to save the model using the `save_pretrained` method of the model. The following is an example of the `save_model` method in the `ModelPool` class and the `AutoModelForCausalLMPool` class.
+- **fast_dev_run**: Quick testing mode. Runs on a single batch instead of the full dataset. Default is `false`. This is invaluable during development for rapid iteration.
 
-        By default, FusionBench will call `modelpool.save_model(model, merged_model_save_path, **merged_model_save_kwargs)` if the options below are provided. That is, additional keyword arguments can be forwarded when supported by the ModelPool implementation.
+  ```bash
+  fusion_bench --fast_dev_run
+  # or
+  fusion_bench fast_dev_run=true
+  ```
 
-- **merged_model_save_kwargs**: Extra keyword arguments forwarded to `modelpool.save_model` when saving the merged model. Provide a dict-like value.
+- **print_config**: Whether to print the resolved configuration before execution. Default is `true`.
 
-    Example (CausalLMPool): save to a local directory and also save the tokenizer and avoid pushing to the hub.
+  ```bash
+  fusion_bench print_config=true
+  ```
 
-    ```bash
-    fusion_bench -c job \
-        merged_model_save_path=outputs/merged_model \
-        merged_model_save_kwargs='{push_to_hub: false, save_tokenizer: true}' \
-        method=linear/weighted_average_for_llama \
-        modelpool=CausalLMPool/simle_mixtral_exp_v4 \
-        taskpool=dummy
-    ```
+- **print_function_call**: Show detailed instantiation calls. Default is `true`.
 
-    !!! note
+  ```bash
+  fusion_bench print_function_call=false
+  ```
 
-        The exact set of supported kwargs is defined by the chosen ModelPool. For example, [`CausalLMPool.save_model`][fusion_bench.modelpool.CausalLMPool.save_model] accepts `push_to_hub`, `save_tokenizer`, etc.
+- **seed**: Random seed for reproducibility. Default is `null` (no seed set).
 
-### method, modelpool and taskpool options
+  ```bash
+  fusion_bench seed=42
+  ```
 
-As mentioned earlier, `method`, `modelpool`, and `taskpool` are the most important options in `fusion_bench`.
-The basic usage is as follows:
+### Output and Logging
+
+- **report_save_path**: Path to save the evaluation report as a JSON file. Default is `{log_dir}/program_report.json`. Set to `false` to skip saving.
+
+  ```bash
+  fusion_bench report_save_path=outputs/my_report.json
+  # or disable
+  fusion_bench report_save_path=false
+  ```
+
+- **merged_model_save_path**: Path to save the merged model. If specified, calls `modelpool.save_model(merged_model, path)`. Default is `null` (no save).
+
+  ```bash
+  fusion_bench merged_model_save_path=outputs/merged_model.pt
+  ```
+
+  The exact save behavior depends on the ModelPool implementation:
+  - **BaseModelPool**: Saves `model.state_dict()` as a `.pt` file.
+  - **CLIPVisionModelPool**: Calls `model.save_pretrained(path)` (saves a directory).
+  - **ResNetForImageClassificationPool**: Saves state dict for torchvision models, `save_pretrained` for transformers models.
+  - **CausalLMPool**: Calls `model.save_pretrained(path)` with optional tokenizer saving.
+
+- **merged_model_save_kwargs**: Extra keyword arguments forwarded to `modelpool.save_model()`. Provide a dict-like value using YAML-style braces.
+
+  ```bash
+  fusion_bench \
+    merged_model_save_path=outputs/merged_model \
+    merged_model_save_kwargs='{push_to_hub: false, save_tokenizer: true}'
+  ```
+
+## Core Components: method, modelpool, taskpool
+
+These three options define the fusion experiment:
 
 ```bash
 fusion_bench method=<METHOD> modelpool=<MODELPOOL> taskpool=<TASKPOOL>
 ```
 
-To override the default configuration, you can specify additional options as follows:
+- **method**: Fusion algorithm (e.g., `simple_average`, `task_arithmetic`, `adamerging/clip`)
+- **modelpool**: Model pool configuration defining which models to merge
+- **taskpool**: Task pool configuration defining evaluation tasks
 
-```bash hl_lines="2-6"
+### Parameter Overrides
+
+Use dot-notation to override nested configuration values:
+
+```bash
 fusion_bench \
-  method=<METHOD> \
-    method.<OPTION_1>=<VALUE_1> \
-      method.<OPTION_1>.<SUBOPTION_1>=<VALUE_1_1> \
-      method.<OPTION_1>.<SUBOPTION_2>=<VALUE_1_2> \
-    method.<OPTION_2>=<VALUE_2> \
-  modelpool=<MODELPOOL> \
-    ...
-  taskpool=<TASKPOOL> \
-    ...
+  method=task_arithmetic \
+  method.scaling_factor=0.7 \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val
 ```
 
-**Paremeter Overrides**:
-In the above example, `<METHOD>`, `<MODELPOOL>`, and `<TASKPOOL>` are the names of the method, model pool, and task pool, respectively.
-`<OPTION_1>`, `<VALUE_1>`, `<SUBOPTION_1>`, `<VALUE_1_1>`, etc., are the options and values for the method.
-In particular, the options for the method are prefixed with `method.`, e.g., `method.<OPTION_1>`. And the suboptions are prefixed with `method.<OPTION_1>.`, e.g., `method.<OPTION_1>.<SUBOPTION_1>`.
+For deeply nested overrides:
+
+```bash
+fusion_bench \
+  method=task_arithmetic \
+  method.optimizer.lr=0.001 \
+  method.optimizer.weight_decay=0.01
+```
+
+To append to lists or set specific indices:
+
+```bash
+fusion_bench taskpool.test_datasets.0.my_field=new_value
+```
+
+## Hydra Override Syntax
+
+Hydra provides powerful syntax for configuration overrides:
+
+### Adding to Dictionaries
+
+```bash
+# Add a new key-value pair
+fusion_bench +method.new_param=value
+
+# Add a new nested section
+fusion_bench ++modelpool.new_section='{key: value}'
+```
+
+### Removing Keys
+
+```bash
+# Remove a config key
+fusion_bench ~method.unwanted_param
+```
+
+### Special Values
+
+```bash
+# Set to null
+fusion_bench method.some_param=null
+
+# Set boolean
+fusion_bench dry_run=true
+
+# Set float with scientific notation
+fusion_bench method.learning_rate=1e-4
+```
+
+### Null vs False
+
+```bash
+# Setting to null (YAML null)
+fusion_bench merged_model_save_path=null
+
+# Setting to false (YAML boolean)
+fusion_bench report_save_path=false
+```
+
+## Multi-Run with Hydra (Sweeps)
+
+Hydra's multi-run mode (`-m`) enables parameter sweeps. Combine with the `launchers` configuration for parallel execution.
+
+### Basic Sweep
+
+```bash
+fusion_bench -m method.scaling_factor=0.1,0.3,0.5,1.0
+```
+
+This runs 4 jobs, one for each value.
+
+### Grid Sweep
+
+```bash
+fusion_bench -m \
+  method.scaling_factor=0.1,0.5,1.0 \
+  method.another_param=true,false
+```
+
+This runs 6 jobs (3 x 2 combinations).
+
+### Using Hydra Launcher
+
+For parallel execution with joblib:
+
+```yaml
+# In your Hydra config
+hydra:
+  launcher:
+    _target_: hydra._internal.core_plugins.basic_launcher.BasicLauncher
+  sweeper:
+    _target_: hydra._internal.core_plugins.basic_sweeper.BasicSweeper
+```
+
+Or use the built-in parallel launcher:
+
+```bash
+fusion_bench -m hydra.launcher.n_jobs=4 method.scaling_factor=0.1,0.3,0.5,1.0
+```
+
+### Output Directory Structure
+
+Multi-run jobs are organized in timestamped directories:
+
+```
+outputs/
+  fusion_bench/
+    2024-01-15/
+      12-00-00/
+        job0/    # scaling_factor=0.1
+        job1/    # scaling_factor=0.3
+        job2/    # scaling_factor=0.5
+        job3/    # scaling_factor=1.0
+```
+
+Use `${now:...}` interpolation in paths for custom organization:
+
+```bash
+fusion_bench -m \
+  report_save_path=outputs/sweep_\${now:%Y%m%d}/\${method_name}/report.json \
+  method.scaling_factor=0.1,0.3,0.5
+```
 
 ## Basic Examples
 
-merge two CLIP models using task arithmetic:
+### Merge Two CLIP Models Using Task Arithmetic
 
 ```bash
 fusion_bench method=task_arithmetic \
@@ -206,36 +378,30 @@ fusion_bench method=task_arithmetic \
   taskpool=clip-vit-base-patch32_svhn_and_mnist
 ```
 
-The overall configuration is as follows:
-
-```yaml linenums="1" hl_lines="1 3 5"
-method: # (1)!
-  ...
-modelpool: # (2)!
-  ...
-taskpool: # (3)!
-  ...
-fast_dev_run: false
-print_config: true
-report_save_path: false
-```
-
-1. Configuration for method, `fusion_bench.method.load_algorithm_from_config` checks the 'name' attribute of the configuration and returns an instance of the corresponding algorithm.
-2. Configuration for model pool, `fusion_bench.modelpool.load_modelpool_from_config` checks the 'type' attribute of the configuration and returns an instance of the corresponding model pool.
-3. Configuration for task pool, `fusion_bench.taskpool.load_taskpool_from_config` checks the 'type' attribute of the configuration and returns an instance of the corresponding task pool.
-
-merge multiple CLIP models using simple averaging:
+### Merge Multiple CLIP Models Using Simple Averaging
 
 ```bash
-fusion_bench method=simple_average modelpool=clip-vit-base-patch32_TA8.yaml taskpool=dummy
+fusion_bench method=simple_average \
+  modelpool=clip-vit-base-patch32_TA8.yaml \
+  taskpool=dummy
+```
+
+### Full Experiment with Model Saving
+
+```bash
+fusion_bench \
+  method=task_arithmetic \
+  method.scaling_factor=0.5 \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  merged_model_save_path=outputs/final_model \
+  report_save_path=outputs/final_report.json \
+  seed=42
 ```
 
 ## Running in Offline Mode
 
-In the offline mode, the model pool will not download the models from the internet.
-Instead, it will use the models that are already downloaded to the local cache.
-
-To run `fusion_bench` in offline mode, you can run the following command before running `fusion_bench`:
+In offline mode, the model pool does not download models from the internet. Instead, it uses models from the local cache.
 
 ```bash
 source offline_mode.sh
@@ -245,15 +411,35 @@ Or set the environment variable according to the content of `offline_mode.sh`.
 
 ## Debugging and Troubleshooting
 
-During algorithm development, you may want to debug the code or inspect the configuration.
-Here are some tips for debugging and troubleshooting.
+### Quick Validation
+
+Use `--cfg` to inspect the resolved configuration without running anything:
+
+```bash
+fusion_bench --cfg job method=task_arithmetic modelpool=my_pool taskpool=dummy
+```
+
+Use `--resolve` to expand interpolations:
+
+```bash
+fusion_bench --cfg job --resolve
+```
+
+### Fast Development Cycle
+
+Use `--fast_dev_run` for rapid iteration during algorithm development:
+
+```bash
+fusion_bench --fast_dev_run method=task_arithmetic ...
+```
+
+This evaluates on a single batch, drastically reducing runtime while still testing the full pipeline.
 
 ### Debugging in VSCode
 
-Visual Studio Code (VSCode) is a popular code editor that supports debugging Python code with Python extension.
-To debug the code using VSCode, you can use the following configuration in your `.vscode/launch.json`:
+Configure `.vscode/launch.json`:
 
-```json linenums="1" hl_lines="8-9"
+```json
 {
     "version": "0.2.0",
     "configurations": [
@@ -261,8 +447,8 @@ To debug the code using VSCode, you can use the following configuration in your 
             "name": "FusionBench with Arguments",
             "type": "debugpy",
             "request": "launch",
-            "module": "fusion_bench.scripts.cli", // (1)!
-            "args": "${command:pickArgs}", // (2)!
+            "module": "fusion_bench.scripts.cli",
+            "args": "${command:pickArgs}",
             "console": "integratedTerminal",
             "justMyCode": true
         }
@@ -270,20 +456,32 @@ To debug the code using VSCode, you can use the following configuration in your 
 }
 ```
 
-1. The `module` field specifies the module to run. In this case, it is `fusion_bench.scripts.cli`. You can also specify the path to the script directly with `program` filed, e.g., `"program": ${workspaceFolder}/fusion_bench/scripts/cli.py`.
-2. The `args` field specifies the arguments to pass to the script. You can use `${command:pickArgs}` to pick the arguments interactively when you run the debugger. Or you can specify the arguments directly, e.g., `"args": ["--config-name", "example_config"]`.
+The `module` field specifies `fusion_bench.scripts.cli`. Use `${command:pickArgs}` to pick arguments interactively, or hardcode them:
 
-Once you have the configuration in your `launch.json`, you can start debugging by selecting the `FusionBench with Arguments` configuration and pressing `F5`.
-
-![alt text](images/vscode_debug.png){ width="200pt" }
+```json
+"args": ["method=simple_average", "modelpool=my_pool", "taskpool=dummy"]
+```
 
 ### Debugging in PyCharm
 
-Debugging in PyCharm with arguments needs to be configured in the `Run/Debug Configurations`.
+1. Click `Run` > `Edit Configurations...`
+2. Click `+` and select `Python`
+3. Set:
+   - **Script path**: Absolute path to `fusion_bench/scripts/cli.py`
+   - **Parameters**: `method=simple_average modelpool=my_pool taskpool=dummy`
+   - **Python interpreter**: Your project's virtual environment
 
-1. Click on the `Run` menu click `Edit Configurations...`
-    ![alt text](images/pycharm_debug_1.png)
-2. Select `+` in top right corner and select `Python`  
-    ![alt text](images/pycharm_debug_2.png)
-3. Provide the name, absolute path of the script (`fusion_bench/scripts/cli.py`) or select the script by clicking three dots (green arrow), script parameters, and python interpreter.  
-    ![alt text](images/pycharm_debug_3.png)
+### Common Errors
+
+- **Missing `_target_`**: Every instantiated component needs a `_target_` field pointing to its Python class. Check the error message for the missing component.
+- **`KeyError` on model name**: The model name does not exist in the pool. Use `--cfg job` to inspect available models.
+- **`ValidationError` on model name**: Model names must follow naming conventions. Special names (`_pretrained_`, `_merged_`) must start and end with underscores.
+- **Import errors with lazy loading**: FusionBench uses `LazyImporter` to defer heavy imports. If you see import errors, ensure dependencies are installed: `pip install fusion-bench[all]`.
+
+### Logging
+
+FusionBench uses Python's `logging` module. Increase verbosity by setting the `LOG_LEVEL` environment variable:
+
+```bash
+LOG_LEVEL=DEBUG fusion_bench method=task_arithmetic ...
+```

--- a/docs/get_started/advanced_examples/ensemble_comparison.md
+++ b/docs/get_started/advanced_examples/ensemble_comparison.md
@@ -1,0 +1,252 @@
+# Comparing Multiple Fusion Methods Side-by-Side
+
+When merging models, one of the first questions to answer is: which fusion method works best for your use case? FusionBench makes it straightforward to run several algorithms against the same set of models and compare their results in a single experiment or across multiple runs.
+
+This guide shows how to compare `simple_average`, `task_arithmetic`, and `adamerging` on the same model pool and evaluation tasks.
+
+## Why Compare Fusion Methods?
+
+Different fusion methods make different assumptions about how models should be combined:
+
+- **Simple Average** (`fusion_bench.method.SimpleAverageAlgorithm`): Equally weights all model parameters. This is the baseline that is surprisingly effective and serves as a strong reference point. Configuration requires no hyperparameters.
+- **Task Arithmetic** (`fusion_bench.method.TaskArithmeticAlgorithm`): Computes task vectors (deltas from a pretrained base) then combines them with a configurable `scaling_factor`. This method explicitly leverages the pretrained model as an anchor.
+- **AdaMerge** (`fusion_bench.method.AdamergingAlgorithm`): An adaptive method that determines per-parameter merge ratios based on the direction of parameter changes, often outperforming naive averaging when models were fine-tuned on complementary tasks.
+
+## Prerequisites
+
+Ensure FusionBench is installed and you have access to the models in your model pool configuration.
+
+```bash
+pip install fusion-bench
+```
+
+## Comparing via CLI
+
+### Running Each Method Separately
+
+The simplest approach is to run each fusion method individually, saving both the merged model and the evaluation report:
+
+```bash
+# 1. Simple Average
+fusion_bench \
+  method=simple_average \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  merged_model_save_path=outputs/simple_average/merged_model.pt \
+  report_save_path=outputs/simple_average/report.json
+```
+
+```bash
+# 2. Task Arithmetic (default scaling_factor=0.3)
+fusion_bench \
+  method=task_arithmetic \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  method.scaling_factor=0.3 \
+  merged_model_save_path=outputs/task_arithmetic/merged_model.pt \
+  report_save_path=outputs/task_arithmetic/report.json
+```
+
+```bash
+# 3. Task Arithmetic with different scaling factor
+fusion_bench \
+  method=task_arithmetic \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  method.scaling_factor=1.0 \
+  merged_model_save_path=outputs/task_arithmetic_sf1/merged_model.pt \
+  report_save_path=outputs/task_arithmetic_sf1/report.json
+```
+
+```bash
+# 4. AdaMerge
+fusion_bench \
+  method=adamerging/clip \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  merged_model_save_path=outputs/adamerging/merged_model.pt \
+  report_save_path=outputs/adamerging/report.json
+```
+
+### Using Hydra Multi-Run for Sweeps
+
+Hydra's multi-run feature (`-multirun` or `-m`) lets you sweep over hyperparameters in a single command. This is ideal for comparing methods or tuning hyperparameters like `scaling_factor`:
+
+```bash
+# Sweep scaling_factor across multiple values
+fusion_bench -m \
+  method=task_arithmetic \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  method.scaling_factor=0.1,0.3,0.5,1.0 \
+  report_save_path=outputs/ta_sweep/\${now:%Y%m%d_%H%M%S}/report.json
+```
+
+Each combination spawns a separate job. You can also sweep over methods:
+
+```bash
+# Sweep across multiple methods
+fusion_bench -m \
+  method=task_arithmetic,adamerging/clip \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  report_save_path=outputs/method_sweep/\${now:%Y%m%d_%H%M%S}/report.json
+```
+
+### Dry Run to Inspect Configurations
+
+Before running the full comparison, validate each configuration:
+
+```bash
+fusion_bench --cfg job \
+  method=simple_average \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val
+```
+
+## Comparing via Python API
+
+For more programmatic control, you can use the FusionBench API directly:
+
+```python
+from fusion_bench import BaseAlgorithm, BaseModelPool
+from fusion_bench.utils import instantiate
+from omegaconf import OmegaConf
+import json
+import os
+
+# Define the model pool (shared across all methods)
+modelpool_cfg = OmegaConf.load(
+    "config/modelpool/ConvNextForImageClassification/convnext-base-224_8-tasks.yaml"
+)
+modelpool = BaseModelPool.from_config(modelpool_cfg)
+
+# Define the methods to compare
+method_configs = {
+    "simple_average": "config/method/simple_average.yaml",
+    "task_arithmetic_0.3": "config/method/task_arithmetic.yaml",  # default scaling_factor=0.3
+}
+
+# Override task_arithmetic scaling factor programmatically
+ta_cfg = OmegaConf.load("config/method/task_arithmetic.yaml")
+ta_cfg.scaling_factor = 0.5
+method_configs["task_arithmetic_0.5"] = ta_cfg
+
+results = {}
+
+for method_name, method_cfg in method_configs.items():
+    print(f"\n{'=' * 60}")
+    print(f"Running method: {method_name}")
+    print(f"{'=' * 60}")
+
+    # Instantiate the algorithm
+    algorithm = BaseAlgorithm.from_config(method_cfg)
+
+    # Make a fresh copy of the model pool for each method
+    fresh_modelpool = BaseModelPool.from_config(modelpool_cfg)
+
+    # Run the fusion
+    merged_model = algorithm.run(fresh_modelpool)
+
+    # Evaluate (using a task pool)
+    taskpool_cfg = OmegaConf.load(
+        "config/taskpool/CLIPVisionModelTaskPool/clip-vit-classification_TA8_val.yaml"
+    )
+    taskpool = taskpool_cfg._target_.from_config(taskpool_cfg)
+    report = taskpool.evaluate(merged_model)
+
+    results[method_name] = report
+
+    # Save the merged model
+    save_dir = f"outputs/programmatic/{method_name}"
+    os.makedirs(save_dir, exist_ok=True)
+    modelpool.save_model(merged_model, f"{save_dir}/merged_model.pt")
+
+    # Save the report
+    with open(f"{save_dir}/report.json", "w") as f:
+        json.dump(report, f, indent=2)
+
+    print(f"Report saved to {save_dir}/report.json")
+
+# Print comparison summary
+print("\n" + "=" * 60)
+print("COMPARISON SUMMARY")
+print("=" * 60)
+for method_name, report in results.items():
+    avg_acc = report.get("average", {}).get("accuracy", "N/A")
+    print(f"  {method_name}: average accuracy = {avg_acc}")
+```
+
+## Interpreting Results
+
+Each report JSON file contains per-task metrics plus an aggregated `average` entry. Typical structure:
+
+```json
+{
+  "model_info": {
+    "trainable_params": 87654321,
+    "all_params": 87654321,
+    "trainable_percentage": 1.0
+  },
+  "sun397": {
+    "accuracy": 0.8234,
+    "loss": 0.612
+  },
+  "stanford-cars": {
+    "accuracy": 0.9102,
+    "loss": 0.312
+  },
+  "average": {
+    "accuracy": 0.8567,
+    "loss": 0.478
+  }
+}
+```
+
+Key metrics to compare across methods:
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `average.accuracy` | Overall performance across all tasks |
+| Per-task `accuracy` | Which method excels on specific domains |
+| `average.loss` | Calibration and confidence of predictions |
+
+## Tips for Effective Comparisons
+
+1. **Fix the model pool**: Always use the same set of models across methods. Different model pools introduce confounding variables.
+
+2. **Include the pretrained model**: Methods like Task Arithmetic require a `_pretrained_` entry in the model pool config. Ensure your YAML includes this:
+
+   ```yaml
+   _target_: fusion_bench.modelpool.ConvNextForImageClassificationPool
+   models:
+     _pretrained_: facebook/convnext-base-224
+     sun397: tanganke/convnext-base-224_sun397
+     stanford-cars: tanganke/convnext-base-224_stanford-cars
+   ```
+
+3. **Use `--fast_dev_run` for quick sanity checks**:
+
+   ```bash
+   fusion_bench --fast_dev_run method=task_arithmetic ...
+   ```
+
+   This evaluates on a single batch instead of the full dataset, letting you verify the pipeline works before committing to a full run.
+
+4. **Control randomness**: Set a fixed seed for reproducibility:
+
+   ```bash
+   fusion_bench seed=42 method=adamerging/clip ...
+   ```
+
+5. **Use Hydra overrides to tune hyperparameters** without editing YAML files. For Task Arithmetic, the key parameter is `scaling_factor`:
+
+   ```bash
+   fusion_bench method=task_arithmetic method.scaling_factor=0.7 ...
+   ```
+
+## Next Steps
+
+- Explore individual method documentation in `docs/algorithms/` for deeper understanding of each algorithm.
+- See the [Save and Load Merged Models](save_and_load_merged_model.md) guide for persisting and reusing merged models.
+- Check out [Hyperparameter Optimization with Optuna](../hyperparameter_optimization_with_optuna.md) for automated search across method hyperparameters.

--- a/docs/get_started/advanced_examples/save_and_load_merged_model.md
+++ b/docs/get_started/advanced_examples/save_and_load_merged_model.md
@@ -1,0 +1,214 @@
+# Saving and Loading Merged Models
+
+After running a fusion algorithm, you typically want to save the merged model for later inference, deployment, or further experimentation. FusionBench provides built-in support for saving merged models via the `merged_model_save_path` CLI flag, and each ModelPool class defines how models are serialized.
+
+## Saving Merged Models via CLI
+
+The primary mechanism for saving merged models is the `merged_model_save_path` top-level configuration option. Set it to a file path or directory, and FusionBench calls `modelpool.save_model()` automatically after fusion completes.
+
+```bash
+fusion_bench \
+  method=simple_average \
+  modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+  taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8_val \
+  merged_model_save_path=outputs/merged_model
+```
+
+### How `save_model` Works
+
+The behavior of `save_model` depends on the ModelPool implementation:
+
+- **BaseModelPool** (default): Saves the model's state dict using `torch.save(model.state_dict(), path)`. The output is a `.pt` file.
+- **CLIPVisionModelPool**: Calls `model.save_pretrained(path)` which saves a directory containing model weights, config, and tokenizer files.
+- **ResNetForImageClassificationPool**: For torchvision models, saves the state dict. For transformers models, calls `model.save_pretrained(path)` and also saves the processor.
+- **CausalLMPool (LLM)**: Calls `model.save_pretrained(path)` and optionally saves the tokenizer and pushes to HuggingFace Hub.
+
+### Additional Save Options
+
+Use `merged_model_save_kwargs` to pass extra keyword arguments to `modelpool.save_model()`. This is particularly useful for Hugging Face model pools:
+
+```bash
+fusion_bench \
+  method=adamerging/clip \
+  modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+  taskpool=dummy \
+  merged_model_save_path=outputs/merged_clip \
+  merged_model_save_kwargs='{safe_serialization: true}'
+```
+
+For CausalLMPool, you can control tokenizer saving and hub upload:
+
+```bash
+fusion_bench -c job \
+  method=linear/weighted_average_for_llama \
+  modelpool=CausalLMPool/smile_mistral_exp_v4 \
+  taskpool=dummy \
+  merged_model_save_path=outputs/merged_llm \
+  merged_model_save_kwargs='{push_to_hub: false, save_tokenizer: true}'
+```
+
+## Saving via Python API
+
+When using the programmatic API, call `save_model` on your ModelPool instance:
+
+```python
+from fusion_bench import BaseAlgorithm, BaseModelPool
+from omegaconf import OmegaConf
+
+# Load configs
+modelpool_cfg = OmegaConf.load(
+    "config/modelpool/ConvNextForImageClassification/convnext-base-224_8-tasks.yaml"
+)
+method_cfg = OmegaConf.load("config/method/task_arithmetic.yaml")
+
+# Instantiate
+modelpool = BaseModelPool.from_config(modelpool_cfg)
+algorithm = BaseAlgorithm.from_config(method_cfg)
+
+# Run fusion
+merged_model = algorithm.run(modelpool)
+
+# Save the merged model
+modelpool.save_model(merged_model, "outputs/my_merged_model.pt")
+```
+
+For HuggingFace-based pools that support `save_pretrained`:
+
+```python
+from fusion_bench.modelpool.clip_vision.modelpool import CLIPVisionModelPool
+
+modelpool = CLIPVisionModelPool.from_config(modelpool_cfg)
+merged_model = algorithm.run(modelpool)
+
+# Save as a directory with config and weights
+modelpool.save_model(merged_model, "outputs/merged_clip_vision/")
+```
+
+## Loading Merged Models for Inference
+
+### Loading State Dict Models (PyTorch)
+
+When the model was saved as a state dict (`.pt` file), load it into a fresh model instance:
+
+```python
+import torch
+from transformers import ConvNextForImageClassification
+
+# Create a model instance (use the same architecture as the base model)
+model = ConvNextForImageClassification.from_pretrained("facebook/convnext-base-224")
+
+# Load the merged state dict
+state_dict = torch.load("outputs/my_merged_model.pt", map_location="cpu")
+model.load_state_dict(state_dict)
+model.eval()
+
+# Run inference
+# ...
+```
+
+### Loading HuggingFace Saved Models
+
+When `save_pretrained` was used, the entire model is self-contained in a directory:
+
+```python
+from transformers import CLIPVisionModel, CLIPProcessor
+
+# Load from the saved directory
+model = CLIPVisionModel.from_pretrained("outputs/merged_clip_vision/")
+processor = CLIPProcessor.from_pretrained("outputs/merged_clip_vision/")
+
+# Run inference
+# inputs = processor(images=my_image, return_tensors="pt")
+# outputs = model(**inputs)
+```
+
+### Loading via ModelPool
+
+For the most seamless experience, use the ModelPool itself to load models:
+
+```python
+from fusion_bench.modelpool.clip_vision.modelpool import CLIPVisionModelPool
+from omegaconf import OmegaConf
+
+# Reference the saved model in a new model pool config
+config = {
+    "_target_": "fusion_bench.modelpool.clip_vision.modelpool.CLIPVisionModelPool",
+    "models": {
+        "my_merged": "outputs/merged_clip_vision/"
+    }
+}
+
+modelpool = CLIPVisionModelPool.from_config(OmegaConf.create(config))
+model = modelpool.load_model("my_merged")
+```
+
+## Common Patterns
+
+### Save Multiple Methods for A/B Testing
+
+```bash
+for method in simple_average task_arithmetic adamerging/clip; do
+    fusion_bench \
+      method=$method \
+      modelpool=ConvNextForImageClassification/convnext-base-224_8-tasks \
+      taskpool=dummy \
+      merged_model_save_path="outputs/models/$method_merged" \
+      report_save_path=false
+done
+```
+
+### Save and Load in a Single Script
+
+```python
+import torch
+import os
+from fusion_bench import BaseAlgorithm, BaseModelPool
+from omegaconf import OmegaConf
+
+SAVE_PATH = "outputs/experiment_001/merged.pt"
+
+def train_and_save():
+    """Run fusion and save the model."""
+    modelpool_cfg = OmegaConf.load(
+        "config/modelpool/ConvNextForImageClassification/convnext-base-224_8-tasks.yaml"
+    )
+    method_cfg = OmegaConf.load("config/method/task_arithmetic.yaml")
+
+    modelpool = BaseModelPool.from_config(modelpool_cfg)
+    algorithm = BaseAlgorithm.from_config(method_cfg)
+
+    merged_model = algorithm.run(modelpool)
+    os.makedirs(os.path.dirname(SAVE_PATH), exist_ok=True)
+    modelpool.save_model(merged_model, SAVE_PATH)
+    print(f"Model saved to {SAVE_PATH}")
+    return SAVE_PATH
+
+def load_and_inference():
+    """Load a saved model and run inference."""
+    state_dict = torch.load(SAVE_PATH, map_location="cpu")
+
+    from transformers import ConvNextForImageClassification
+    model = ConvNextForImageClassification.from_pretrained(
+        "facebook/convnext-base-224"
+    )
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    # Your inference logic here
+    return model
+
+# Usage
+model_path = train_and_save()
+inference_model = load_and_inference()
+```
+
+## Troubleshooting
+
+- **File not found on load**: Verify the path matches exactly what was passed to `merged_model_save_path`. For HuggingFace saves, the path is a directory, not a file.
+- **Shape mismatch on state dict load**: Ensure the model architecture you are loading into matches the fused model. Use the same base model (e.g., `_pretrained_` entry) for loading.
+- **Missing processor/tokenizer**: If you need the processor or tokenizer, use a ModelPool that supports `save_pretrained` rather than the base `save_model` which only saves state dicts.
+
+## Related
+
+- [Comparing Multiple Fusion Methods](ensemble_comparison.md) — Use saved models from different methods for side-by-side comparison.
+- [CLI Reference](../../cli/fusion_bench.md) — Full documentation of `merged_model_save_path` and `merged_model_save_kwargs` flags.

--- a/docs/guides/custom_modelpool.md
+++ b/docs/guides/custom_modelpool.md
@@ -1,0 +1,291 @@
+# Creating a Custom ModelPool
+
+A ModelPool is the component in FusionBench responsible for managing a collection of models and their associated datasets. It handles model loading, instantiation, and serialization. This guide walks you through creating a custom ModelPool from scratch.
+
+## Understanding the BaseModelPool
+
+The base class `fusion_bench.modelpool.base_pool.BaseModelPool` provides the foundation for all model pools. Key features it provides out of the box:
+
+- **Model registry**: A dictionary (`_models`) mapping model names to configurations or instances.
+- **Dataset management**: Optional `train_datasets`, `val_datasets`, and `test_datasets` dictionaries.
+- **Special model names**: Support for `_pretrained_` (base/pretrained model) and `_merged_` (merged model) keys.
+- **YAML serialization**: Inherits from `BaseYAMLSerializable` for config-to-object conversion.
+- **Hydra integration**: Inherits from `HydraConfigMixin` for seamless Hydra configuration handling.
+
+### Key Methods in BaseModelPool
+
+| Method | Purpose |
+|--------|---------|
+| `load_model(model_name_or_config)` | Load a model by name (from `_models`) or from a direct DictConfig |
+| `save_model(model, path)` | Save model state dict to `path` via `torch.save` |
+| `add_model(model_name, model_or_config)` | Add a model to the pool at runtime |
+| `get_model_config(model_name)` | Get the raw config for a model |
+| `models()` | Generator yielding all regular (non-special) models |
+| `named_models()` | Generator yielding `(name, model)` tuples |
+| `load_pretrained_model()` | Load the model registered under `_pretrained_` |
+
+## Step 1: Inherit from BaseModelPool
+
+Create a new Python file in `fusion_bench/modelpool/`. Your class must inherit from `BaseModelPool`:
+
+```python
+from typing import Any, Dict, Optional, Union
+
+from omegaconf import DictConfig
+from torch import nn
+
+from fusion_bench import BaseModelPool
+
+
+class MyCustomModelPool(BaseModelPool):
+    """A custom model pool for my specific model type."""
+
+    def __init__(
+        self,
+        models: DictConfig,
+        *,
+        some_custom_param: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(models, **kwargs)
+        self.some_custom_param = some_custom_param
+```
+
+## Step 2: Implement `load_model`
+
+The `load_model` method is the heart of any ModelPool. It takes a model name (string) or a DictConfig and returns an instantiated `nn.Module`.
+
+The base implementation already handles three cases:
+
+1. **String name in `_models`** with a `dict`/`DictConfig` config -> calls `instantiate()` with `_target_`.
+2. **Pre-instantiated `nn.Module`** in `_models` -> returns it directly.
+3. **Direct DictConfig** passed as argument -> calls `instantiate()`.
+
+Override this method when you need custom loading logic (e.g., calling `from_pretrained`, resolving platform-specific paths, or applying post-processing):
+
+```python
+from typing_extensions import override
+
+@override
+def load_model(
+    self, model_name_or_config: Union[str, DictConfig], *args, **kwargs
+) -> nn.Module:
+    """Load a model from the pool with custom logic."""
+    if isinstance(model_name_or_config, str) and model_name_or_config in self._models:
+        model_name = model_name_or_config
+        model_config = self._models[model_name]
+
+        if isinstance(model_config, str):
+            # String path - use it as a HuggingFace model ID or local path
+            model = MyModelClass.from_pretrained(model_config, *args, **kwargs)
+            return model
+
+        if isinstance(model_config, nn.Module):
+            # Already instantiated
+            return model_config
+
+        # For dict/DictConfig, delegate to parent
+        return super().load_model(model_name_or_config, *args, **kwargs)
+
+    return super().load_model(model_name_or_config, *args, **kwargs)
+```
+
+### Real Example: CLIPVisionModelPool
+
+The `CLIPVisionModelPool` in `fusion_bench/modelpool/clip_vision/modelpool.py` demonstrates a production-ready override:
+
+```python
+@override
+def load_model(self, model_name_or_config, *args, **kwargs) -> CLIPVisionModel:
+    if isinstance(model_name_or_config, str) and model_name_or_config in self._models:
+        match self._models[model_name_or_config]:
+            case str() as model_path:
+                # Resolve path (supports HuggingFace and ModelScope)
+                repo_path = resolve_repo_path(model_path, repo_type="model",
+                                              platform=self._platform)
+                return CLIPVisionModel.from_pretrained(repo_path, *args, **kwargs)
+            case nn.Module() as model:
+                return model
+            case _:
+                return super().load_model(model_name_or_config, *args, **kwargs)
+    return super().load_model(model_name_or_config, *args, **kwargs)
+```
+
+## Step 3: Optionally Override `save_model`
+
+The default `save_model` uses `torch.save(model.state_dict(), path)`. Override it when your models require a different serialization format:
+
+```python
+@override
+def save_model(self, model: nn.Module, path: str, *args, **kwargs):
+    """Save the model using HuggingFace format."""
+    model.save_pretrained(path)
+```
+
+## Step 4: Register `_config_mapping` (if adding new attributes)
+
+If your ModelPool has custom attributes that should be serialized to/from YAML, add them to `_config_mapping`:
+
+```python
+class MyCustomModelPool(BaseModelPool):
+    _config_mapping = BaseModelPool._config_mapping | {
+        "_custom_processor": "processor",
+        "_platform": "platform",
+    }
+
+    def __init__(self, models: DictConfig, *,
+                 custom_processor: Optional[DictConfig] = None,
+                 platform: str = "hf",
+                 **kwargs):
+        super().__init__(models, **kwargs)
+        self._custom_processor = custom_processor
+        self._platform = platform
+```
+
+Alternatively, use the `@auto_register_config` decorator to auto-register all `__init__` parameters:
+
+```python
+from fusion_bench.mixins import auto_register_config
+
+@auto_register_config
+class MyCustomModelPool(BaseModelPool):
+    def __init__(self, models, custom_processor: Optional[DictConfig] = None,
+                 platform: str = "hf", **kwargs):
+        super().__init__(models=models, **kwargs)
+        self.custom_processor = custom_processor
+        self.platform = platform
+```
+
+## Step 5: Create the YAML Configuration
+
+Every ModelPool needs a matching YAML config file. Place it under `config/modelpool/your_pool_name/`:
+
+```yaml
+# config/modelpool/MyCustomModelPool/example.yaml
+_target_: fusion_bench.modelpool.MyCustomModelPool
+_recursive_: False
+
+models:
+  _pretrained_: myorg/my-base-model
+  task_a: myorg/my-model-finetuned-task-a
+  task_b: myorg/my-model-finetuned-task-b
+  task_c: myorg/my-model-finetuned-task-c
+
+# Optional: train/val/test datasets
+train_datasets: null
+val_datasets: null
+test_datasets: null
+
+# Custom parameters
+custom_processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: myorg/my-base-model
+
+platform: hf
+```
+
+Key points:
+
+- **`_target_`**: Must point to the fully qualified Python class path.
+- **`_recursive_: False`**: Prevents recursive instantiation of nested configs.
+- **`models`**: Dictionary mapping names to model IDs or DictConfig objects. Always include `_pretrained_` when using methods like Task Arithmetic.
+- **Special names**: Model names starting and ending with underscores (e.g., `_pretrained_`, `_merged_`) are treated as special models.
+
+## Complete Working Example
+
+Here is a complete, minimal custom ModelPool for a hypothetical BERT-like classifier:
+
+```python
+# fusion_bench/modelpool/bert_classifier_pool.py
+import logging
+from typing import Optional, Union
+from typing_extensions import override
+
+from omegaconf import DictConfig
+from torch import nn
+from transformers import AutoModelForSequenceClassification
+
+from fusion_bench import BaseModelPool
+
+log = logging.getLogger(__name__)
+
+
+class BertClassifierModelPool(BaseModelPool):
+    """Model pool for BERT-based sequence classification models."""
+
+    _config_mapping = BaseModelPool._config_mapping | {
+        "_num_labels": "num_labels",
+    }
+
+    def __init__(
+        self,
+        models: DictConfig,
+        *,
+        num_labels: Optional[int] = None,
+        **kwargs,
+    ):
+        super().__init__(models, **kwargs)
+        self._num_labels = num_labels
+
+    @override
+    def load_model(
+        self, model_name_or_config: Union[str, DictConfig], *args, **kwargs
+    ) -> nn.Module:
+        if isinstance(model_name_or_config, str) and model_name_or_config in self._models:
+            model_config = self._models[model_name_or_config]
+
+            if isinstance(model_config, str):
+                log.info(f"Loading BERT classifier from: {model_config}")
+                kwargs.setdefault("num_labels", self._num_labels)
+                return AutoModelForSequenceClassification.from_pretrained(
+                    model_config, *args, **kwargs
+                )
+
+            if isinstance(model_config, nn.Module):
+                return model_config
+
+        return super().load_model(model_name_or_config, *args, **kwargs)
+
+    @override
+    def save_model(self, model: nn.Module, path: str, *args, **kwargs):
+        """Save using HuggingFace format."""
+        model.save_pretrained(path)
+```
+
+With config file:
+
+```yaml
+# config/modelpool/BertClassifierPool/glue_tasks.yaml
+_target_: fusion_bench.modelpool.bert_classifier_pool.BertClassifierModelPool
+_recursive_: False
+
+models:
+  _pretrained_: bert-base-uncased
+  sst2: user/bert-sst2-finetuned
+  mnli: user/bert-mnli-finetuned
+
+num_labels: 2
+```
+
+Usage:
+
+```bash
+fusion_bench \
+  method=simple_average \
+  modelpool=BertClassifierPool/glue_tasks \
+  taskpool=dummy
+```
+
+## Best Practices
+
+1. **Always call `super().__init__()`**: The base class handles model validation, special name checks, and Hydra integration.
+2. **Use `@override` decorator**: From `typing_extensions`, this marks overridden methods and catches errors at runtime.
+3. **Handle all three config types**: In `load_model`, handle `str`, `nn.Module`, and `DictConfig` cases. Delegate unexpected types to `super().load_model()`.
+4. **Log model loading**: Use `rank_zero_only` logging to avoid duplicate logs in distributed settings.
+5. **Support `*args, **kwargs`**: Always forward extra arguments so algorithms can pass device, dtype, or other parameters.
+6. **Validate model names**: The base class validates names during `__init__`, but you can add custom validation in `load_model`.
+
+## Next Steps
+
+- See `fusion_bench/modelpool/clip_vision/modelpool.py` and `fusion_bench/modelpool/resnet_for_image_classification.py` for production examples.
+- Read the [Custom TaskPool](custom_taskpool.md) guide to create a matching evaluation component.

--- a/docs/guides/custom_taskpool.md
+++ b/docs/guides/custom_taskpool.md
@@ -1,0 +1,414 @@
+# Creating a Custom TaskPool
+
+A TaskPool is responsible for evaluating fused models on specific tasks or datasets. It defines the evaluation logic, metrics, and data loading pipeline. This guide shows you how to build a custom TaskPool from scratch.
+
+## Understanding the BaseTaskPool
+
+The base class `fusion_bench.taskpool.base_pool.BaseTaskPool` provides the foundation. Its key characteristics:
+
+- **Abstract `evaluate` method**: Subclasses must implement `evaluate(self, model, *args, **kwargs) -> Dict[str, Any]`.
+- **YAML serialization**: Inherits from `BaseYAMLSerializable` for config management.
+- **Return format**: The `evaluate` method returns a dictionary mapping task names to metric dictionaries.
+
+### The `evaluate` Method Signature
+
+```python
+from abc import abstractmethod
+from typing import Any, Dict
+
+class BaseTaskPool(BaseYAMLSerializable):
+    _program = None
+    _config_key = "taskpool"
+
+    @abstractmethod
+    def evaluate(self, model: Any, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Evaluate the model and return a structured report."""
+        pass
+```
+
+The expected return format is:
+
+```python
+{
+    "model_info": {
+        "trainable_params": 1234567,
+        "all_params": 1234567,
+        "trainable_percentage": 1.0,
+    },
+    "task_name_1": {
+        "accuracy": 0.95,
+        "loss": 0.15,
+    },
+    "task_name_2": {
+        "accuracy": 0.87,
+        "loss": 0.42,
+    },
+    "average": {
+        "accuracy": 0.91,
+        "loss": 0.285,
+    }
+}
+```
+
+## Step 1: Inherit from BaseTaskPool
+
+Create a new file in `fusion_bench/taskpool/`:
+
+```python
+from typing import Any, Dict
+
+from fusion_bench import BaseTaskPool
+
+
+class MyCustomTaskPool(BaseTaskPool):
+    """A custom task pool for evaluating on my specific tasks."""
+
+    def __init__(self, test_datasets: dict, **kwargs):
+        super().__init__(**kwargs)
+        self._test_datasets = test_datasets
+```
+
+## Step 2: Implement the `evaluate` Method
+
+The `evaluate` method is the core of your TaskPool. It receives the fused model and must return a metrics dictionary.
+
+### Minimal Example
+
+```python
+from torch import nn
+import torch
+
+
+class MyCustomTaskPool(BaseTaskPool):
+    def __init__(self, test_datasets: dict, **kwargs):
+        super().__init__(**kwargs)
+        self._test_datasets = test_datasets
+
+    def evaluate(self, model: nn.Module, **kwargs) -> Dict[str, Any]:
+        """Evaluate the model on each configured test dataset."""
+        report = {}
+
+        for task_name, dataset_config in self._test_datasets.items():
+            # Load dataset (you can use the instantiate utility)
+            dataset = instantiate(dataset_config)
+
+            # Create dataloader
+            dataloader = torch.utils.data.DataLoader(
+                dataset, batch_size=32, shuffle=False
+            )
+
+            # Run evaluation
+            task_result = self._run_evaluation(model, dataloader)
+            report[task_name] = task_result
+
+        # Compute average
+        if len(report) > 0:
+            report["average"] = self._compute_average(report)
+
+        return report
+
+    def _run_evaluation(self, model, dataloader) -> Dict[str, float]:
+        model.eval()
+        correct = 0
+        total = 0
+        total_loss = 0.0
+
+        with torch.no_grad():
+            for batch in dataloader:
+                inputs, targets = batch
+                outputs = model(inputs)
+                loss = self._compute_loss(outputs, targets)
+                preds = outputs.argmax(dim=1)
+                correct += (preds == targets).sum().item()
+                total += targets.size(0)
+                total_loss += loss.item()
+
+        return {
+            "accuracy": correct / total,
+            "loss": total_loss / len(dataloader),
+        }
+
+    def _compute_loss(self, outputs, targets):
+        import torch.nn.functional as F
+        return F.cross_entropy(outputs, targets)
+
+    @staticmethod
+    def _compute_average(report: Dict[str, Any]) -> Dict[str, float]:
+        accuracies = [v["accuracy"] for v in report.values() if "accuracy" in v]
+        losses = [v["loss"] for v in report.values() if "loss" in v]
+        avg = {}
+        if accuracies:
+            avg["accuracy"] = sum(accuracies) / len(accuracies)
+        if losses:
+            avg["loss"] = sum(losses) / len(losses)
+        return avg
+```
+
+### Real Example: ImageClassificationTaskPool
+
+The `ImageClassificationTaskPool` in `fusion_bench/taskpool/image_classification.py` demonstrates a production implementation with Lightning Fabric integration:
+
+```python
+from fusion_bench import BaseTaskPool, LightningFabricMixin, auto_register_config
+
+@auto_register_config
+class ImageClassificationTaskPool(LightningFabricMixin, BaseTaskPool):
+
+    def __init__(
+        self,
+        test_datasets: DictConfig | Dict[str, Any],
+        *,
+        processor: DictConfig | Any,
+        dataloader_kwargs: DictConfig,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+    def evaluate(self, model: nn.Module, **kwargs) -> Dict[str, Any]:
+        classifier = self.fabric.to_device(model)
+        classifier.eval()
+        report = {}
+
+        for task_name, test_dataloader in self.test_dataloaders.items():
+            result = self._evaluate(classifier, test_dataloader, task_name)
+            report[task_name] = result
+
+        report["average"] = self._compute_average(report)
+        return report
+```
+
+Key patterns used in the real implementation:
+
+- **`LightningFabricMixin`**: Provides device management and distributed training support. Access via `self.fabric`.
+- **`@auto_register_config`**: Automatically registers `__init__` parameters into `_config_mapping`.
+- **`torch.no_grad()`**: Used in `_evaluate` to disable gradient computation during inference.
+- **`tqdm` progress bars**: For tracking evaluation progress.
+
+## Step 3: Add Model Summary Information
+
+Most TaskPools include basic model information in their report:
+
+```python
+from fusion_bench.utils.parameters import count_parameters
+
+def evaluate(self, model: nn.Module, **kwargs) -> Dict[str, Any]:
+    training_params, all_params = count_parameters(model)
+
+    report = {
+        "model_info": {
+            "trainable_params": training_params,
+            "all_params": all_params,
+            "trainable_percentage": training_params / all_params,
+        }
+    }
+
+    # ... add task results ...
+    return report
+```
+
+## Step 4: Configure Test Datasets in YAML
+
+TaskPool configurations live under `config/taskpool/`. The `test_datasets` key defines which datasets to evaluate on.
+
+### Simple TaskPool Config
+
+```yaml
+# config/taskpool/my_custom_task.yaml
+_target_: fusion_bench.taskpool.MyCustomTaskPool
+
+test_datasets:
+  dataset_a:
+    _target_: torchvision.datasets.CIFAR10
+    root: ./data
+    train: false
+    download: true
+  dataset_b:
+    _target_: torchvision.datasets.MNIST
+    root: ./data
+    train: false
+    download: true
+```
+
+### Using Hydra Defaults (recommended for complex setups)
+
+For shared dataset configurations, use Hydra defaults:
+
+```yaml
+# config/taskpool/CLIPVisionModelTaskPool/clip-vit-classification_TA8_val.yaml
+defaults:
+  - CLIPVisionModelTaskPool@: _template
+  - /dataset/image_classification/val@test_datasets:
+      - sun397
+      - stanford-cars
+      - resisc45
+      - eurosat
+      - svhn
+      - gtsrb
+      - mnist
+      - dtd
+```
+
+The `CLIPVisionModelTaskPool@: _template` line references a template config that defines the TaskPool class and shared settings. The `/dataset/image_classification/val@test_datasets` line injects dataset configs into the `test_datasets` key.
+
+## Complete Working Example
+
+Here is a full TaskPool for text classification:
+
+```python
+# fusion_bench/taskpool/text_classification.py
+import json
+import os
+from typing import Any, Dict
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+from torchmetrics import Accuracy
+from tqdm.auto import tqdm
+
+from fusion_bench import BaseTaskPool, get_rankzero_logger, instantiate
+from fusion_bench.utils.parameters import count_parameters
+
+log = get_rankzero_logger(__name__)
+
+
+class TextClassificationTaskPool(BaseTaskPool):
+    """Task pool for text classification evaluation."""
+
+    def __init__(
+        self,
+        test_datasets: Dict[str, Any],
+        dataloader_kwargs: Dict[str, Any] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._test_datasets = test_datasets
+        self.dataloader_kwargs = dataloader_kwargs or {"batch_size": 32, "shuffle": False}
+        self._is_setup = False
+
+    def setup(self):
+        """Pre-load datasets and dataloaders."""
+        self.test_dataloaders = {}
+        for name, ds_config in self._test_datasets.items():
+            dataset = instantiate(ds_config)
+            self.test_dataloaders[name] = DataLoader(dataset, **self.dataloader_kwargs)
+        self._is_setup = True
+
+    def evaluate(self, model: nn.Module, **kwargs) -> Dict[str, Any]:
+        if not self._is_setup:
+            self.setup()
+
+        model.eval()
+        report = {}
+
+        # Model info
+        training_params, all_params = count_parameters(model)
+        report["model_info"] = {
+            "trainable_params": training_params,
+            "all_params": all_params,
+            "trainable_percentage": training_params / all_params,
+        }
+
+        # Evaluate on each task
+        for task_name, dataloader in tqdm(
+            self.test_dataloaders.items(), desc="Evaluating tasks"
+        ):
+            result = self._evaluate_task(model, dataloader)
+            report[task_name] = result
+
+        # Average
+        accuracies = [v["accuracy"] for v in report.values() if isinstance(v, dict) and "accuracy" in v]
+        if accuracies:
+            report["average"] = {"accuracy": sum(accuracies) / len(accuracies)}
+
+        log.info(f"Evaluation Result: {report}")
+        return report
+
+    def _evaluate_task(self, model: nn.Module, dataloader: DataLoader) -> Dict[str, float]:
+        correct = 0
+        total = 0
+
+        with torch.no_grad():
+            for batch in dataloader:
+                inputs = batch["input_ids"]
+                attention_mask = batch["attention_mask"]
+                labels = batch["labels"]
+
+                outputs = model(input_ids=inputs, attention_mask=attention_mask)
+                logits = outputs.logits
+                preds = logits.argmax(dim=1)
+
+                correct += (preds == labels).sum().item()
+                total += labels.size(0)
+
+        return {"accuracy": correct / total}
+```
+
+With config:
+
+```yaml
+# config/taskpool/TextClassificationTaskPool/glue.yaml
+_target_: fusion_bench.taskpool.text_classification.TextClassificationTaskPool
+
+test_datasets:
+  sst2:
+    _target_: datasets.load_dataset
+    path: glue
+    name: sst2
+    split: validation
+  mnli:
+    _target_: datasets.load_dataset
+    path: glue
+    name: mnli
+    split: validation_matched
+
+dataloader_kwargs:
+  batch_size: 32
+  shuffle: false
+```
+
+## Using LightningFabricMixin for Distributed Evaluation
+
+When your evaluation involves large datasets or GPUs, add `LightningFabricMixin` as the first mixin:
+
+```python
+from fusion_bench import BaseTaskPool, LightningFabricMixin, auto_register_config
+
+@auto_register_config
+class DistributedEvaluationTaskPool(LightningFabricMixin, BaseTaskPool):
+    def __init__(self, test_datasets: dict, **kwargs):
+        super().__init__(**kwargs)
+
+    def evaluate(self, model: nn.Module, **kwargs) -> Dict[str, Any]:
+        # Move model to correct device
+        model = self.fabric.to_device(model)
+        model.eval()
+
+        # Setup dataloaders for distributed inference
+        dataloader = self.fabric.setup_dataloaders(self.test_dataloader)
+
+        # ... run evaluation ...
+```
+
+Note the mixin order: `LightningFabricMixin` comes before `BaseTaskPool` so its `__init__` runs first.
+
+## Best Practices
+
+1. **Return consistent structure**: Always include `model_info` and `average` keys in your report.
+2. **Use `torch.no_grad()`**: Never compute gradients during evaluation.
+3. **Use progress bars**: `tqdm` provides visibility into long evaluations.
+4. **Log results**: Use `get_rankzero_logger` to log on the main process only.
+5. **Separate setup from evaluate**: Pre-load datasets in a `setup()` method to avoid reloading on each call.
+6. **Handle device placement**: Use `self.fabric.to_device()` when using `LightningFabricMixin`.
+
+## Troubleshooting
+
+- **`NotImplementedError` on `evaluate`**: Ensure your subclass implements the method (do not forget the `@abstractmethod` contract).
+- **Missing test datasets**: Check that your YAML config includes `test_datasets` and each dataset config has a valid `_target_`.
+- **Device mismatch**: If using GPUs, ensure both model and tensors are on the same device.
+
+## Next Steps
+
+- See `fusion_bench/taskpool/dummy.py` for the simplest possible TaskPool (model introspection only).
+- See `fusion_bench/taskpool/image_classification.py` for a full image classification TaskPool.
+- Read the [Custom ModelPool](custom_modelpool.md) guide to create a matching ModelPool.

--- a/docs/guides/fusion_bench/mixins/lightning_fabric.md
+++ b/docs/guides/fusion_bench/mixins/lightning_fabric.md
@@ -1,5 +1,191 @@
 # LightningFabricMixin
 
+The `LightningFabricMixin` provides deep integration with PyTorch Lightning Fabric, enabling distributed computing, device management, and structured logging for FusionBench algorithms. This mixin abstracts away the complexity of multi-GPU training, data parallelism, and experiment tracking, allowing algorithm implementations to focus on their core logic.
+
+## Overview
+
+Lightning Fabric is a lightweight library from the Lightning ecosystem that provides a clean API for distributed training without the overhead of full framework abstractions like PyTorch Lightning's `LightningModule`. The mixin integrates Fabric into FusionBench's three-component architecture, specifically into the **Method** (algorithm) layer.
+
+## Key Features
+
+### 1. Distributed Computing
+
+The mixin handles distributed setup automatically. When you call `self.fabric` from your algorithm, it initializes a `Lightning Fabric` instance based on the YAML configuration.
+
+```python
+class MyAlgorithm(LightningFabricMixin, BaseAlgorithm):
+    def run(self, modelpool):
+        # Models are automatically placed on the correct device
+        model = modelpool.load_model("model_a")
+        model = self.to_device(model)
+
+        # Fabric handles gradient synchronization in distributed settings
+        with self.fabric.init_module():
+            model = self.fabric.setup(model)
+```
+
+### 2. Device Management
+
+The `to_device()` method moves tensors or modules to the appropriate device (GPU, TPU, or CPU) as configured by Fabric:
+
+```python
+# Move a model to the correct device
+model = self.to_device(model)
+
+# Move a tensor to the correct device
+tensor = self.to_device(torch.randn(32, 768))
+```
+
+### 3. Logging
+
+The mixin provides multiple logging methods:
+
+```python
+# Log a single metric
+self.log("train/loss", loss_value, step=epoch)
+
+# Log multiple metrics at once
+self.log_dict({"train/acc": acc, "train/loss": loss}, step=epoch)
+
+# Log optimizer learning rates
+self.log_optimizer_lr(optimizer, step=epoch)
+
+# Log hyperparameters (saves to YAML)
+self.log_hyperparams(self.config)
+```
+
+### 4. Hyperparameter Persistence
+
+The `log_hyperparams()` method saves the full Hydra configuration as a YAML file in the log directory. This is decorated with `@rank_zero_only`, so it only executes on the main process in distributed settings.
+
+```python
+# In your algorithm's on_run_start() hook:
+def on_run_start(self):
+    super().on_run_start()
+    self.log_hyperparams()  # Saves config.yaml to log directory
+```
+
+### 5. Log Directory Management
+
+The `log_dir` property retrieves the log directory from the configured logger. It handles multiple logger types:
+
+- **TensorBoardLogger**: Returns `logger.log_dir`
+- **SwanLabLogger**: Returns `logger.save_dir` or `logger._logdir`
+- **MLFlowLogger**: Returns `logger.save_dir` or falls back to program config
+
+## Usage Patterns
+
+### Basic Usage
+
+The simplest way to use the mixin is through multiple inheritance:
+
+```python
+from fusion_bench.mixins import LightningFabricMixin
+from fusion_bench.method import BaseAlgorithm
+
+class MyAlgorithm(LightningFabricMixin, BaseAlgorithm):
+    def run(self, modelpool):
+        model = modelpool.load_model("_pretrained_")
+        model = self.to_device(model)
+        model = self.fabric.setup(model)
+        # ... your algorithm logic ...
+        return model
+```
+
+### With Configuration
+
+The mixin reads the `fabric` section from your Hydra config:
+
+```yaml
+# config/method/my_algorithm.yaml
+_target_: fusion_bench.method.MyAlgorithm
+fabric:
+  _target_: lightning.Fabric
+  accelerator: gpu
+  devices: 2
+  strategy: ddp
+  precision: "16-mixed"
+```
+
+### With TensorBoard
+
+To enable TensorBoard logging:
+
+```yaml
+fabric:
+  _target_: lightning.Fabric
+  accelerator: gpu
+  devices: 1
+  loggers:
+    - _target_: lightning.fabric.loggers.TensorBoardLogger
+      root_dir: outputs
+      name: tensorboard
+```
+
+Then access the SummaryWriter:
+
+```python
+writer = self.tensorboard_summarywriter
+writer.add_scalar("train/loss", loss, step=epoch)
+```
+
+## Advanced Features
+
+### FSDP Support
+
+For large models that require Fully Sharded Data Parallel training:
+
+```python
+from fusion_bench.mixins.lightning_fabric import get_policy, get_size_based_auto_wrap_policy
+
+policy = get_size_based_auto_wrap_policy(min_num_params=100_000_000)
+```
+
+### MLFlow Artifact Logging
+
+When using MLFlow as the logger, you can log files and directories as artifacts:
+
+```python
+# Log a single file
+self.log_artifact(local_path="model.pth", artifact_path="checkpoints")
+
+# Log a directory of files
+self.log_artifacts(local_dir="outputs/plots", artifact_path="figures")
+```
+
+### Debug Mode
+
+Check if the program is running in debug (fast_dev_run) mode:
+
+```python
+if self.is_debug_mode:
+    # Run with reduced iterations for debugging
+    max_epochs = 1
+```
+
+## Lifecycle Hooks
+
+The mixin provides a `finalize()` method that should be called during cleanup:
+
+```python
+def on_run_end(self):
+    super().on_run_end()
+    self.finalize()  # Properly clean up Fabric resources
+```
+
+The `__del__` destructor also calls `finalize()` automatically, ensuring proper cleanup even if not explicitly called. For MLFlow loggers, `finalize()` sets the run status to "success" or "failed" based on whether an exception occurred.
+
+## Important Notes
+
+1. **Mixin order matters**: Always place `LightningFabricMixin` before `BaseAlgorithm` in the inheritance list.
+2. **Lazy initialization**: The Fabric instance is created lazily on first access via `self.fabric`. If no `fabric` config is found, a default single-device Fabric is created.
+3. **CLI detection**: If running via the Lightning CLI (`lightning run`), the mixin skips calling `launch()` since the CLI handles that.
+4. **Rank zero operations**: Methods like `log_hyperparams` are decorated with `@rank_zero_only`, so they only execute on the main process.
+5. **Config integration**: The log directory from the logger is automatically injected into `config.log_dir` if not already set.
+
 ## Reference
 
-::: fusion_bench.mixins.lightning_fabric
+::: fusion_bench.mixins.lightning_fabric.LightningFabricMixin
+::: fusion_bench.mixins.lightning_fabric._fabric_has_logger
+::: fusion_bench.mixins.lightning_fabric.get_policy
+::: fusion_bench.mixins.lightning_fabric.get_size_based_auto_wrap_policy

--- a/docs/guides/fusion_bench/mixins/simple_profiler.md
+++ b/docs/guides/fusion_bench/mixins/simple_profiler.md
@@ -1,9 +1,179 @@
 # SimpleProfilerMixin
 
-The `SimpleProfilerMixin` is a powerful and easy-to-use tool for adding profiling capabilities to your Python classes.
-This mixin is particularly useful for developers who need to optimize performance in their applications or want to gain insights into the time consumption of different parts of their code. By incorporating `SimpleProfilerMixin` into your classes, you can easily track and analyze the execution time of various operations, helping you identify bottlenecks and optimize your code effectively.
+The `SimpleProfilerMixin` provides lightweight, wall-clock timing for code blocks within your FusionBench algorithms. Built on Lightning's `SimpleProfiler`, it measures execution time for named actions, making it easy to identify performance bottlenecks without the overhead of statistical profilers.
+
+## Overview
+
+Unlike statistical profilers (cProfile, pyinstrument) that sample or trace every function call, `SimpleProfilerMixin` focuses on timing specific, named blocks of code. This makes it ideal for:
+
+- Measuring the duration of distinct pipeline stages (data loading, model fusion, evaluation)
+- Comparing execution times across algorithm variants
+- Quick performance diagnostics during development
+
+## Basic Usage
+
+### Context Manager (Recommended)
+
+The cleanest way to profile code is using the `with` context manager:
+
+```python
+from fusion_bench.mixins import SimpleProfilerMixin
+from fusion_bench.method import BaseAlgorithm
+
+class MyAlgorithm(SimpleProfilerMixin, BaseAlgorithm):
+    def run(self, modelpool):
+        with self.profile("model_loading"):
+            models = [modelpool.load_model(name) for name in modelpool.model_names]
+
+        with self.profile("weight_averaging"):
+            merged = average_models(models)
+
+        with self.profile("device_transfer"):
+            merged = self.to_device(merged)
+
+        # Print the profiling summary
+        self.print_profile_summary("Fusion Pipeline Timing")
+```
+
+### Manual Start/Stop
+
+For cases where context managers don't fit your code structure:
+
+```python
+def run(self, modelpool):
+    self.start_profile("data_preparation")
+    # ... data loading and preprocessing ...
+    self.stop_profile("data_preparation")
+
+    self.start_profile("fusion_step")
+    # ... model fusion logic ...
+    self.stop_profile("fusion_step")
+```
+
+## Key Methods
+
+### `profile(action_name)` — Context Manager
+
+Starts profiling on entry and stops on exit (even if an exception occurs). The action name appears in the summary output.
+
+```python
+with self.profile("training_epoch"):
+    for batch in dataloader:
+        loss = train_step(batch)
+```
+
+### `start_profile(action_name)` and `stop_profile(action_name)`
+
+Manual control for more flexible profiling:
+
+```python
+self.start_profile("inference")
+results = model.predict(test_data)
+self.stop_profile("inference")
+```
+
+### `print_profile_summary(title=None)`
+
+Outputs a formatted table showing all profiled actions with their execution times. Decorated with `@rank_zero_only`, so it only prints on the main process in distributed settings.
+
+```python
+self.print_profile_summary("Algorithm Performance Breakdown")
+```
+
+### `profiler` Property
+
+Access the underlying `SimpleProfiler` instance directly for advanced usage. Lazy-initialized on first access.
+
+## Integration with Other Mixins
+
+The mixin works seamlessly with `LightningFabricMixin`:
+
+```python
+class MyAlgorithm(SimpleProfilerMixin, LightningFabricMixin, BaseAlgorithm):
+    def run(self, modelpool):
+        with self.profile("model_setup"):
+            model = modelpool.load_model("_pretrained_")
+            model = self.to_device(model)
+            model = self.fabric.setup(model)
+
+        with self.profile("training"):
+            for epoch in range(self.num_epochs):
+                self._train_epoch(model, epoch)
+
+        self.print_profile_summary("Training Pipeline")
+```
+
+## Practical Examples
+
+### Profiling a Model Merging Algorithm
+
+```python
+class MergingAlgorithm(SimpleProfilerMixin, BaseAlgorithm):
+    def run(self, modelpool):
+        # Profile each stage of the merging pipeline
+        with self.profile("load_models"):
+            pretrained = modelpool.load_model("_pretrained_")
+            finetuned_models = [
+                modelpool.load_model(name) for name in modelpool.model_names
+            ]
+
+        with self.profile("compute_task_vectors"):
+            task_vectors = [
+                compute_task_vector(ft, pretrained)
+                for ft in finetuned_models
+            ]
+
+        with self.profile("apply_masking"):
+            masked_vectors = [self.apply_mask(tv) for tv in task_vectors]
+
+        with self.profile("merge_vectors"):
+            merged_vector = sum(masked_vectors)
+
+        with self.profile("apply_to_pretrained"):
+            merged_model = apply_vector(pretrained, merged_vector)
+
+        self.print_profile_summary("Merging Algorithm Profile")
+        return merged_model
+```
+
+### Profiling Ensemble Evaluation
+
+```python
+class EnsembleAlgorithm(SimpleProfilerMixin, BaseAlgorithm):
+    def run(self, modelpool):
+        with self.profile("load_all_models"):
+            models = self._load_models(modelpool)
+
+        with self.profile("forward_pass"):
+            predictions = self._forward(models)
+
+        with self.profile("ensemble_aggregation"):
+            final_pred = self._aggregate(predictions)
+
+        with self.profile("metric_computation"):
+            metrics = self._compute_metrics(final_pred)
+
+        self.print_profile_summary("Ensemble Evaluation Profile")
+        return metrics
+```
+
+## Best Practices
+
+1. **Use descriptive names**: Choose action names that clearly describe the operation (e.g., "load_pretrained_model" not "step1").
+2. **Profile at the right granularity**: Profile coarse-grained blocks (entire phases) rather than individual lines. For fine-grained profiling, use `PyinstrumentProfilerMixin`.
+3. **Always print the summary**: Call `print_profile_summary()` after your profiling blocks to see the results.
+4. **Distributed awareness**: The summary only prints on rank zero. In multi-GPU runs, timing reflects the synchronized wall-clock time.
+5. **Don't profile in production**: Remove or disable profiling calls before benchmarking final performance, as the act of profiling adds small overhead.
+
+## SimpleProfiler vs PyinstrumentProfiler
+
+| Aspect | SimpleProfilerMixin | PyinstrumentProfilerMixin |
+|---|---|---|
+| Granularity | Block-level (named sections) | Function-level (full call tree) |
+| Overhead | Minimal | Moderate |
+| Use case | Pipeline timing | Bottleneck diagnosis |
+| Output | Duration table | Call tree with percentages |
 
 ## Reference
 
 ::: fusion_bench.mixins.simple_profiler.SimpleProfilerMixin
-

--- a/examples/magmax/README.md
+++ b/examples/magmax/README.md
@@ -1,0 +1,105 @@
+# MagMax
+
+Reproduction scripts for **MagMax: Leveraging Model Merging for Seamless
+Continual Learning** (Marczak et al., ECCV 2024,
+[arXiv:2407.06322](https://arxiv.org/abs/2407.06322)) on FusionBench.
+
+The merge rule is element-wise selection of the task vector with the
+largest absolute magnitude across tasks:
+
+```
+tau_t        = theta_t - theta_0
+tau_max[j]   = tau_{argmax_t |tau_t[j]|}[j]
+theta_merged = theta_0 + alpha * tau_max
+```
+
+## Two fine-tuning protocols
+
+The MagMax paper evaluates the merge rule under two distinct
+fine-tuning protocols, and the paper's headline numbers come from the
+*sequential* one:
+
+- **Independent FT (`ind-ft`)** — each task is fine-tuned from the
+  pretrained model in isolation. This is what the original Task
+  Arithmetic / TIES papers use, and what the publicly hosted CLIP
+  checkpoints from `tanganke/...` provide. The shell scripts below run
+  MagMax on these ready-made checkpoints.
+- **Sequential FT (`seq-ft`)** — each task is fine-tuned starting from
+  the *previous* task's weights. The paper's "seamless continual
+  learning" claim is about this setting, and the official
+  `merge_8datasets.py` is wired for it. We reproduce this end-to-end
+  with `sequential_ft_and_merge.py` below.
+
+## Files
+
+| File | Setting |
+|---|---|
+| `clip_vit_base_patch32_TA8.sh` | `ind-ft`, CLIP-ViT-B/32, TA8 |
+| `clip_vit_base_patch16_TA8.sh` | `ind-ft`, CLIP-ViT-B/16, TA8 |
+| `clip_vit_base_patch32_TALL14.sh` | `ind-ft`, CLIP-ViT-B/32, TALL14 |
+| `sweep_scaling_factor.sh` | `ind-ft` $\alpha$ sweep on TA8 |
+| `sequential_ft_and_merge.py` | `seq-ft` — trains the 8 snapshots itself, then merges and evaluates |
+
+## Independent FT (quick start)
+
+```bash
+bash examples/magmax/clip_vit_base_patch32_TA8.sh
+```
+
+Override the scaling factor from the command line:
+
+```bash
+fusion_bench \
+    method=magmax/magmax \
+    method.scaling_factor=0.5 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8
+```
+
+## Sequential FT (paper-faithful reproduction)
+
+`sequential_ft_and_merge.py` mirrors the official
+`tmp/magmax/finetune_8datasets.py + merge_8datasets.py` pair end-to-end.
+
+Task order (paper): `Cars -> MNIST -> EuroSAT -> SVHN -> RESISC45 -> SUN397 -> DTD -> GTSRB`.
+
+```bash
+# ViT-B/32, ~50 min on one H100
+python examples/magmax/sequential_ft_and_merge.py \
+    --base-model openai/clip-vit-base-patch32 \
+    --output-dir outputs/magmax/seq_ft_b32 \
+    --num-steps-per-task 2500 \
+    --scaling-factor 0.5
+
+# ViT-B/16 — closer to the paper's setting, ~2-3h
+python examples/magmax/sequential_ft_and_merge.py \
+    --base-model openai/clip-vit-base-patch16 \
+    --output-dir outputs/magmax/seq_ft_b16 \
+    --num-steps-per-task 2500 \
+    --scaling-factor 0.5
+```
+
+Per-task snapshots are written to
+`<output-dir>/{idx:02d}_{task_name}/` in HuggingFace format; the merged
+model lands under `merged_alpha<...>/`; the evaluation report is the
+JSON next to the merged model.
+
+To re-run only the merge step on existing snapshots:
+
+```bash
+python examples/magmax/sequential_ft_and_merge.py \
+    --output-dir outputs/magmax/seq_ft_b32 \
+    --skip-training \
+    --scaling-factor 0.6   # try a different alpha
+```
+
+## Notes on closing the gap to the paper
+
+The MagMax paper trains its own CLIP checkpoints (with `open_clip` and a
+per-task epoch schedule) and reports numbers against those. Running MagMax
+against the public `tanganke/clip-vit-base-patch{16,32}_*` checkpoints
+(which is what the `*_TA8.sh` scripts do) lands a few points below the
+paper because the underlying checkpoints differ — not because the merge
+rule deviates. The `sequential_ft_and_merge.py` path trains the
+checkpoints inside this repo, so numbers there are directly comparable
+to the paper's seq-ft column once you match the iteration budget.

--- a/examples/magmax/clip_vit_base_patch16_TA8.sh
+++ b/examples/magmax/clip_vit_base_patch16_TA8.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Reproduce MagMax on the 8-task CLIP-ViT-B/16 vision benchmark.
+set -euo pipefail
+
+fusion_bench \
+    fabric.loggers.name=magmax/ViT-B-16_TA8 \
+    method=magmax/magmax \
+    method.scaling_factor=0.5 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch16_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8 \
+    report_save_path=outputs/magmax/clip-vit-base-patch16_TA8.json

--- a/examples/magmax/clip_vit_base_patch32_TA8.sh
+++ b/examples/magmax/clip_vit_base_patch32_TA8.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Reproduce MagMax (Marczak et al., ECCV 2024) on the 8-task CLIP-ViT-B/32
+# vision benchmark used by Task Arithmetic.
+set -euo pipefail
+
+fusion_bench \
+    fabric.loggers.name=magmax/ViT-B-32_TA8 \
+    method=magmax/magmax \
+    method.scaling_factor=0.5 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8 \
+    report_save_path=outputs/magmax/clip-vit-base-patch32_TA8.json

--- a/examples/magmax/clip_vit_base_patch32_TALL14.sh
+++ b/examples/magmax/clip_vit_base_patch32_TALL14.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Reproduce MagMax on the 14-task CLIP-ViT-B/32 vision benchmark (TALL14).
+set -euo pipefail
+
+fusion_bench \
+    fabric.loggers.name=magmax/ViT-B-32_TALL14 \
+    method=magmax/magmax \
+    method.scaling_factor=0.5 \
+    modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TALL14 \
+    taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TALL14 \
+    report_save_path=outputs/magmax/clip-vit-base-patch32_TALL14.json

--- a/examples/magmax/sequential_ft_and_merge.py
+++ b/examples/magmax/sequential_ft_and_merge.py
@@ -1,0 +1,347 @@
+"""End-to-end reproduction of MagMax (Marczak et al., ECCV 2024) on the
+8-task CLIP image-classification benchmark.
+
+This script faithfully follows the *sequential* fine-tuning protocol from
+``tmp/magmax/finetune_8datasets.py`` (the paper's official code) and then
+applies the FusionBench MagMax merger on the resulting per-task snapshots.
+
+Pipeline
+--------
+1. Load CLIP (HF transformers) and freeze the text encoder + visual
+   projection + logit scale.
+2. Build a frozen zero-shot classification head for each of the 8 tasks
+   using ``get_classnames_and_templates``.
+3. Iterate through the tasks in the paper's order
+   (Cars -> MNIST -> EuroSAT -> SVHN -> RESISC45 -> SUN397 -> DTD -> GTSRB).
+   For each task, continue fine-tuning the vision tower from the previous
+   task's weights for ``num_steps_per_task`` iterations with AdamW + cosine
+   LR and gradient clipping.
+4. After each task, save the CLIPVisionModel to
+   ``<output_dir>/<task_idx>_<task_name>/`` in HuggingFace format.
+5. After all tasks, run :class:`fusion_bench.method.MagMaxAlgorithm` over the
+   8 snapshots and evaluate the merged model on the TA8 test sets.
+
+Usage
+-----
+::
+
+    .venv/bin/python examples/magmax/sequential_ft_and_merge.py \\
+        --base-model openai/clip-vit-base-patch32 \\
+        --output-dir outputs/magmax/seq_ft_b32 \\
+        --num-steps-per-task 2000 \\
+        --scaling-factor 0.5
+
+To skip training (e.g. resume after a crash) and just rerun the MagMax merge
+on existing snapshots, pass ``--skip-training``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from copy import deepcopy
+from typing import Dict, List, Tuple
+
+import torch
+from datasets import load_dataset
+from torch import nn
+from torch.utils.data import DataLoader
+from tqdm.auto import tqdm
+from transformers import CLIPModel, CLIPProcessor, CLIPVisionModel
+
+from fusion_bench.dataset.image_dataset import ImageClassificationDataset
+from fusion_bench.method.magmax import magmax_merge
+from fusion_bench.models.hf_clip import HFCLIPClassifier
+from fusion_bench.tasks.clip_classification import get_classnames_and_templates
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("magmax.seq_ft")
+
+
+# Task order from the official ``finetune_8datasets.py``. Names here match
+# FusionBench's dataset registry keys so that ``get_classnames_and_templates``
+# and the HF dataset loader keep working unchanged.
+TASKS: List[Tuple[str, dict]] = [
+    ("stanford-cars", {"path": "tanganke/stanford_cars"}),
+    ("mnist", {"path": "mnist"}),
+    ("eurosat", {"path": "tanganke/eurosat"}),
+    ("svhn", {"path": "svhn", "name": "cropped_digits"}),
+    ("resisc45", {"path": "tanganke/resisc45"}),
+    ("sun397", {"path": "tanganke/sun397"}),
+    ("dtd", {"path": "tanganke/dtd"}),
+    ("gtsrb", {"path": "tanganke/gtsrb"}),
+]
+
+
+def _load_split(spec: dict, split: str):
+    """Load a HF dataset following the same conventions as the existing
+    FusionBench dataset configs."""
+    if "name" in spec:
+        return load_dataset(spec["path"], spec["name"], split=split)
+    return load_dataset(spec["path"], split=split)
+
+
+def _build_classifier_heads(
+    base_model: str,
+    device: torch.device,
+) -> Tuple[CLIPProcessor, Dict[str, torch.Tensor], torch.Tensor, float]:
+    """Pre-compute frozen zero-shot text embeddings for each task.
+
+    Returns the CLIP processor, a dict of zero-shot weights per task, the
+    visual projection (a Linear layer mapping vision-tower features into the
+    shared CLIP embedding space) and the scalar ``logit_scale.exp()``.
+    """
+    log.info("Building frozen zero-shot classifier heads from %s", base_model)
+    full_clip = CLIPModel.from_pretrained(base_model).to(device).eval()
+    processor = CLIPProcessor.from_pretrained(base_model)
+    classifier = HFCLIPClassifier(full_clip, processor)
+
+    zeroshot_weights: Dict[str, torch.Tensor] = {}
+    for task_name, _ in TASKS:
+        classnames, templates = get_classnames_and_templates(task_name)
+        classifier.set_classification_task(classnames, templates)
+        zeroshot_weights[task_name] = classifier.zeroshot_weights.detach().clone()
+
+    visual_projection = deepcopy(full_clip.visual_projection).requires_grad_(False)
+    logit_scale = float(full_clip.logit_scale.detach().exp().item())
+
+    # Free the text tower; we only need the vision tower from here on.
+    del full_clip, classifier
+    torch.cuda.empty_cache()
+    return processor, zeroshot_weights, visual_projection, logit_scale
+
+
+def _vision_logits(
+    vision_model: CLIPVisionModel,
+    visual_projection: nn.Linear,
+    images: torch.Tensor,
+    text_weights: torch.Tensor,
+    logit_scale: float,
+) -> torch.Tensor:
+    """Compute CLIP zero-shot logits for a single batch."""
+    pooled = vision_model(pixel_values=images).pooler_output
+    image_embeds = visual_projection(pooled)
+    image_embeds = image_embeds / image_embeds.norm(dim=-1, keepdim=True)
+    return logit_scale * image_embeds @ text_weights.t()
+
+
+def _train_one_task(
+    vision_model: CLIPVisionModel,
+    visual_projection: nn.Linear,
+    text_weights: torch.Tensor,
+    logit_scale: float,
+    processor: CLIPProcessor,
+    train_spec: dict,
+    task_name: str,
+    num_steps: int,
+    batch_size: int,
+    lr: float,
+    weight_decay: float,
+    grad_clip: float,
+    device: torch.device,
+    num_workers: int,
+) -> CLIPVisionModel:
+    """Fine-tune ``vision_model`` for ``num_steps`` iterations on a task."""
+    train_ds = _load_split(train_spec, "train")
+    dataset = ImageClassificationDataset(train_ds, processor)
+    loader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=True,
+        drop_last=True,
+    )
+    text_weights = text_weights.to(device)
+    visual_projection.to(device)
+    vision_model.to(device).train()
+
+    optimizer = torch.optim.AdamW(
+        [p for p in vision_model.parameters() if p.requires_grad],
+        lr=lr,
+        weight_decay=weight_decay,
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=num_steps)
+    loss_fn = nn.CrossEntropyLoss()
+
+    pbar = tqdm(total=num_steps, desc=f"FT {task_name}", dynamic_ncols=True)
+    step = 0
+    while step < num_steps:
+        for batch in loader:
+            if step >= num_steps:
+                break
+            images, labels = batch
+            images = images.to(device, non_blocking=True)
+            labels = labels.to(device, non_blocking=True)
+
+            logits = _vision_logits(
+                vision_model, visual_projection, images, text_weights, logit_scale
+            )
+            loss = loss_fn(logits, labels)
+            optimizer.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(
+                [p for p in vision_model.parameters() if p.requires_grad], grad_clip
+            )
+            optimizer.step()
+            scheduler.step()
+            step += 1
+            if step % 20 == 0:
+                pbar.set_postfix(loss=float(loss.item()), lr=scheduler.get_last_lr()[0])
+            pbar.update(1)
+    pbar.close()
+    return vision_model.eval()
+
+
+def _evaluate(
+    vision_model: CLIPVisionModel,
+    visual_projection: nn.Linear,
+    zeroshot_weights: Dict[str, torch.Tensor],
+    logit_scale: float,
+    processor: CLIPProcessor,
+    device: torch.device,
+    batch_size: int,
+    num_workers: int,
+) -> Dict[str, float]:
+    """Evaluate the (possibly merged) vision model on all 8 test sets."""
+    vision_model.to(device).eval()
+    visual_projection.to(device)
+    results: Dict[str, float] = {}
+    with torch.no_grad():
+        for task_name, spec in TASKS:
+            test_ds = _load_split(spec, "test")
+            loader = DataLoader(
+                ImageClassificationDataset(test_ds, processor),
+                batch_size=batch_size,
+                shuffle=False,
+                num_workers=num_workers,
+                pin_memory=True,
+            )
+            text_w = zeroshot_weights[task_name].to(device)
+            correct = total = 0
+            for images, labels in tqdm(loader, desc=f"eval {task_name}", leave=False):
+                images = images.to(device, non_blocking=True)
+                labels = labels.to(device, non_blocking=True)
+                logits = _vision_logits(
+                    vision_model, visual_projection, images, text_w, logit_scale
+                )
+                correct += int((logits.argmax(-1) == labels).sum().item())
+                total += int(labels.numel())
+            acc = correct / max(total, 1)
+            log.info("eval %s: %.4f", task_name, acc)
+            results[task_name] = acc
+    results["average"] = sum(results.values()) / len(results)
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-model", default="openai/clip-vit-base-patch32")
+    parser.add_argument("--output-dir", default="outputs/magmax/seq_ft_b32")
+    parser.add_argument("--num-steps-per-task", type=int, default=2000)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=1e-5)
+    parser.add_argument("--weight-decay", type=float, default=0.0)
+    parser.add_argument("--grad-clip", type=float, default=1.0)
+    parser.add_argument("--num-workers", type=int, default=8)
+    parser.add_argument("--scaling-factor", type=float, default=0.5)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--skip-training",
+        action="store_true",
+        help="Reuse existing per-task checkpoints under output-dir.",
+    )
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    os.makedirs(args.output_dir, exist_ok=True)
+    log.info("Using device: %s, output dir: %s", device, args.output_dir)
+
+    processor, zeroshot_weights, visual_projection, logit_scale = (
+        _build_classifier_heads(args.base_model, device)
+    )
+
+    pretrained_dir = os.path.join(args.output_dir, "_pretrained_")
+    if not os.path.isdir(pretrained_dir):
+        log.info("Saving pretrained snapshot to %s", pretrained_dir)
+        CLIPVisionModel.from_pretrained(args.base_model).save_pretrained(pretrained_dir)
+
+    # Sequential FT phase
+    vision_model: CLIPVisionModel = CLIPVisionModel.from_pretrained(args.base_model)
+    for idx, (task_name, spec) in enumerate(TASKS):
+        ckpt_dir = os.path.join(args.output_dir, f"{idx:02d}_{task_name}")
+        if args.skip_training and os.path.isdir(ckpt_dir):
+            log.info("[%d/%d] skip-training: reloading %s", idx + 1, len(TASKS), ckpt_dir)
+            vision_model = CLIPVisionModel.from_pretrained(ckpt_dir)
+            continue
+
+        log.info("[%d/%d] sequential FT on %s", idx + 1, len(TASKS), task_name)
+        vision_model = _train_one_task(
+            vision_model=vision_model,
+            visual_projection=visual_projection,
+            text_weights=zeroshot_weights[task_name],
+            logit_scale=logit_scale,
+            processor=processor,
+            train_spec=spec,
+            task_name=task_name,
+            num_steps=args.num_steps_per_task,
+            batch_size=args.batch_size,
+            lr=args.lr,
+            weight_decay=args.weight_decay,
+            grad_clip=args.grad_clip,
+            device=device,
+            num_workers=args.num_workers,
+        )
+        log.info("Saving snapshot to %s", ckpt_dir)
+        vision_model.save_pretrained(ckpt_dir)
+
+    # Merge phase
+    log.info("Loading 8 sequential snapshots for MagMax merge")
+    finetuned: List[CLIPVisionModel] = [
+        CLIPVisionModel.from_pretrained(
+            os.path.join(args.output_dir, f"{idx:02d}_{task_name}")
+        )
+        for idx, (task_name, _) in enumerate(TASKS)
+    ]
+    pretrained = CLIPVisionModel.from_pretrained(pretrained_dir)
+    log.info("Running MagMax (scaling_factor=%s)", args.scaling_factor)
+    merged = magmax_merge(
+        pretrained, finetuned, scaling_factor=args.scaling_factor, inplace=True
+    )
+    merged_dir = os.path.join(args.output_dir, f"merged_alpha{args.scaling_factor}")
+    merged.save_pretrained(merged_dir)
+    log.info("Saved merged model to %s", merged_dir)
+
+    # Free per-task finetuned models before eval to save GPU memory
+    del finetuned
+    torch.cuda.empty_cache()
+
+    # Evaluation phase
+    results = _evaluate(
+        merged,
+        visual_projection,
+        zeroshot_weights,
+        logit_scale,
+        processor,
+        device,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+    )
+    report_path = os.path.join(
+        args.output_dir, f"magmax_seqft_alpha{args.scaling_factor}.json"
+    )
+    with open(report_path, "w") as f:
+        json.dump(results, f, indent=2)
+    log.info("Wrote report to %s", report_path)
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/magmax/sweep_scaling_factor.sh
+++ b/examples/magmax/sweep_scaling_factor.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Sweep MagMax `scaling_factor` (alpha) on CLIP-ViT-B/32 TA8 to reproduce
+# the alpha-sensitivity curve from the paper.
+set -euo pipefail
+
+for alpha in 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0; do
+    fusion_bench \
+        fabric.loggers.name=magmax/ViT-B-32_TA8/alpha_${alpha} \
+        method=magmax/magmax \
+        method.scaling_factor=${alpha} \
+        modelpool=CLIPVisionModelPool/clip-vit-base-patch32_TA8 \
+        taskpool=CLIPVisionModelTaskPool/clip-vit-classification_TA8 \
+        report_save_path=outputs/magmax/clip-vit-base-patch32_TA8_alpha_${alpha}.json
+done

--- a/fusion_bench/method/__init__.py
+++ b/fusion_bench/method/__init__.py
@@ -41,6 +41,7 @@ _import_structure = {
     "weighted_average": ["WeightedAverageAlgorithm", "WeightedAverageForLLama"],
     "task_arithmetic": ["TaskArithmeticAlgorithm"],
     "ties_merging": ["TiesMergingAlgorithm"],
+    "magmax": ["MagMaxAlgorithm", "magmax_merge"],
     "dare": ["DareSimpleAverage", "DareTaskArithmetic", "DareTiesMerging"],
     "fisher_merging": [
         "FisherMergingAlgorithm",
@@ -257,6 +258,7 @@ if TYPE_CHECKING:
         SparseLoForLlama,
     )
     from .tall_mask import TallMaskTaskArithmeticAlgorithm
+    from .magmax import MagMaxAlgorithm, magmax_merge
     from .task_arithmetic import TaskArithmeticAlgorithm
     from .task_singular_vector import TaskSingularVectorMerging
     from .ties_merging import TiesMergingAlgorithm

--- a/fusion_bench/method/magmax/__init__.py
+++ b/fusion_bench/method/magmax/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa F401
+from .magmax import MagMaxAlgorithm, magmax_merge

--- a/fusion_bench/method/magmax/magmax.py
+++ b/fusion_bench/method/magmax/magmax.py
@@ -1,0 +1,212 @@
+R"""
+MagMax: Leveraging Model Merging for Seamless Continual Learning.
+
+Reference:
+    Marczak, D., Twardowski, B., Trzcinski, T., Cygert, S.
+    "MagMax: Leveraging Model Merging for Seamless Continual Learning."
+    ECCV 2024.
+    https://arxiv.org/abs/2407.06322
+
+The MagMax merging rule is element-wise maximum-magnitude task-vector
+selection:
+
+    For each task t in {1, ..., T} compute the task vector
+        tau_t = theta_t - theta_0
+    where theta_t is a fine-tuned model and theta_0 is the pretrained model.
+
+    For every parameter index j choose the task vector with the largest
+    absolute value at that position:
+        tau_max[j] = tau_{t*(j)}[j],   t*(j) = argmax_t |tau_t[j]|
+
+    The merged model is then:
+        theta_merged = theta_0 + scaling_factor * tau_max
+
+This contrasts with Task Arithmetic, which sums all task vectors instead of
+selecting per-element by magnitude.
+
+Implementation notes (matched to the official release at
+https://github.com/danielm1405/magmax):
+- Tie-breaking is done with ``>=``, i.e. later task vectors win when their
+  absolute magnitude equals the current best (see
+  ``src/merging/task_vectors.py::merge_max_abs``).
+- Integer / boolean buffer keys (e.g. ``position_ids``) are skipped during
+  task-vector computation and copied through from the pretrained state.
+- The released 8-dataset reproduction script uses ``scaling_coef = 0.5``
+  for independent fine-tunes; we expose this as ``scaling_factor`` and use
+  it as the default.
+"""
+
+import logging
+from copy import deepcopy
+from typing import Dict, List, Mapping, Optional, Union
+
+import torch
+from torch import Tensor, nn
+
+from fusion_bench import LazyStateDict
+from fusion_bench.method.base_algorithm import BaseAlgorithm
+from fusion_bench.mixins import SimpleProfilerMixin, auto_register_config
+from fusion_bench.modelpool import BaseModelPool
+from fusion_bench.utils.type import StateDictType, TorchModelType
+
+log = logging.getLogger(__name__)
+
+
+_SKIP_DTYPES = (torch.int64, torch.int32, torch.int16, torch.int8, torch.uint8, torch.bool)
+
+
+def _is_float_param(t: Tensor) -> bool:
+    """Return True if a parameter is a floating-point tensor we should merge.
+
+    Mirrors the reference implementation, which skips integer / boolean
+    buffers such as ``position_ids``.
+    """
+    return t.dtype not in _SKIP_DTYPES
+
+
+@torch.no_grad()
+def _magmax_select(
+    task_vectors: List[StateDictType],
+) -> StateDictType:
+    """Element-wise maximum-magnitude selection across task vectors.
+
+    For each parameter tensor key, fold the task vectors in order using the
+    ``>=`` tie-breaking rule from the reference implementation: a later task
+    vector replaces the running selection when its absolute value at a given
+    position is greater than or equal to the current best.
+    """
+    if len(task_vectors) == 0:
+        raise ValueError("magmax requires at least one task vector.")
+
+    merged: Dict[str, Tensor] = {k: v.clone() for k, v in task_vectors[0].items()}
+    for tv in task_vectors[1:]:
+        for key, current in tv.items():
+            running = merged[key]
+            mask = current.abs() >= running.abs()
+            merged[key] = torch.where(mask, current, running)
+    return merged
+
+
+@torch.no_grad()
+def magmax_merge(
+    pretrained_model: TorchModelType,
+    finetuned_models: List[TorchModelType],
+    scaling_factor: float = 1.0,
+    inplace: bool = True,
+) -> TorchModelType:
+    """Merge fine-tuned models into the pretrained model using MagMax.
+
+    Args:
+        pretrained_model: Base / pretrained model that supplies theta_0.
+        finetuned_models: A list of task-specific fine-tuned models. Each
+            must have the same parameter shapes as ``pretrained_model``.
+        scaling_factor: Multiplier applied to the merged task vector before
+            adding it back to the pretrained weights.
+        inplace: If True, mutate ``pretrained_model``; otherwise operate on
+            a deep copy.
+
+    Returns:
+        The merged model with the MagMax task vector applied.
+    """
+    if not inplace:
+        pretrained_model = deepcopy(pretrained_model)
+
+    ptm_sd = pretrained_model.state_dict(keep_vars=True)
+    merge_keys = [k for k, v in ptm_sd.items() if _is_float_param(v)]
+    task_vectors: List[StateDictType] = []
+    for model in finetuned_models:
+        ft_sd = model.state_dict(keep_vars=True)
+        task_vectors.append({k: ft_sd[k] - ptm_sd[k] for k in merge_keys})
+
+    tau_max = _magmax_select(task_vectors)
+    merged_sd = dict(ptm_sd)
+    for k in merge_keys:
+        merged_sd[k] = ptm_sd[k] + scaling_factor * tau_max[k]
+    pretrained_model.load_state_dict(merged_sd)
+    return pretrained_model
+
+
+@auto_register_config
+class MagMaxAlgorithm(
+    SimpleProfilerMixin,
+    BaseAlgorithm,
+):
+    """MagMax model merging algorithm.
+
+    Computes per-task task vectors against the pretrained model, selects
+    element-wise the value with the maximum absolute magnitude across
+    tasks, scales by ``scaling_factor`` and adds the result back to the
+    pretrained weights.
+
+    Attributes:
+        scaling_factor: Multiplier applied to the merged task vector before
+            adding it back to the pretrained model (alpha in the paper).
+        inplace: If True, mutate the loaded pretrained model in place.
+    """
+
+    def __init__(
+        self,
+        scaling_factor: float = 0.5,
+        inplace: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+    @torch.no_grad()
+    def run(self, modelpool: Union[BaseModelPool, Dict[str, nn.Module]]) -> nn.Module:
+        if not isinstance(modelpool, BaseModelPool):
+            modelpool = BaseModelPool(modelpool)
+
+        log.info(
+            "Fusing %d models using MagMax (scaling_factor=%s).",
+            len(modelpool.model_names),
+            self.scaling_factor,
+        )
+
+        with self.profile("load pretrained"):
+            pretrained_model = modelpool.load_model("_pretrained_")
+            ptm_sd: Mapping[str, Tensor] = pretrained_model.state_dict(keep_vars=True)
+            merge_keys = [k for k, v in ptm_sd.items() if _is_float_param(v)]
+
+        # Stream task vectors: hold only the running max-magnitude selection
+        # in memory instead of all task vectors. Tie-breaking uses ``>=`` to
+        # match the reference implementation.
+        tau_max: Optional[Dict[str, Tensor]] = None
+        for model_name in modelpool.model_names:
+            with self.profile("load model"):
+                model = modelpool.load_model(model_name)
+            with self.profile("merge weights"):
+                ft_sd = model.state_dict(keep_vars=True)
+                if tau_max is None:
+                    tau_max = {k: (ft_sd[k] - ptm_sd[k]).clone() for k in merge_keys}
+                else:
+                    for k in merge_keys:
+                        new_tv = ft_sd[k] - ptm_sd[k]
+                        mask = new_tv.abs() >= tau_max[k].abs()
+                        tau_max[k] = torch.where(mask, new_tv, tau_max[k])
+
+        assert tau_max is not None, "modelpool produced no finetuned models"
+
+        with self.profile("merge weights"):
+            merged_sd = dict(ptm_sd)
+            for k in merge_keys:
+                merged_sd[k] = ptm_sd[k] + self.scaling_factor * tau_max[k]
+
+        self.print_profile_summary()
+
+        if isinstance(pretrained_model, nn.Module):
+            model = pretrained_model if self.inplace else deepcopy(pretrained_model)
+            model.load_state_dict(merged_sd)
+        elif isinstance(pretrained_model, LazyStateDict):
+            model = deepcopy(pretrained_model.meta_module)
+            model = model.to_empty(device=pretrained_model._device)
+            result = model.load_state_dict(merged_sd, strict=False)
+            if result.unexpected_keys:
+                raise ValueError(
+                    f"Unexpected keys in state dict: {result.unexpected_keys}"
+                )
+            if result.missing_keys:
+                log.warning(f"Missing keys in state dict: {result.missing_keys}")
+        else:
+            raise TypeError(f"Unsupported model type: {type(pretrained_model)}")
+        return model

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,8 +19,9 @@ nav:
           - Simple Ensemble: algorithms/simple_ensemble.md
           - Weighted Ensemble: algorithms/weighted_ensemble.md
           - Max-Model Predictor: algorithms/max-model_predictor.md
-            # - Model Specification: algorithms/specification_ensemble.md
+          - DAWE: algorithms/dawe.md
       - Model Merging:
+          - Linear/ExPO: algorithms/linear.md
           - Simple Averaging: algorithms/simple_averaging.md
           - Weighted Averaging: algorithms/weighted_averaging.md
           - algorithms/slerp.md
@@ -30,11 +31,24 @@ nav:
           - AdaMerging: algorithms/adamerging.md
           - RegMean: algorithms/regmean.md
           - RegMean++: algorithms/regmean_plusplus.md
+          - DARE: algorithms/dare.md
+          - OPCM: algorithms/opcm.md
+          - Model Stock: algorithms/model_stock.md
+          - RandES: algorithms/randes.md
           - Concrete Subspace: algorithms/concrete_subspace.md
           - Task Singular Vector: algorithms/task_singular_vector.md
           - Isotropic Merging: algorithms/isotropic_merging.md
           - WUDI-Merging: algorithms/wudi_merging.md
           - EMR Merging: algorithms/emr_merging.md
+          - Gossip: algorithms/gossip.md
+          - DoP: algorithms/dop.md
+          - FW Merging: algorithms/fw_merging.md
+          - DogeTA: algorithms/doge_ta.md
+          - AdaSVD: algorithms/ada_svd.md
+          - Singular Value Calibration: algorithms/singular_value_calibration.md
+          - Surgery: algorithms/surgery.md
+          - Tall Mask: algorithms/tall_mask.md
+          - Trust Region: algorithms/trust_region.md
       - Model Mixing:
           - Depth Upscaling: algorithms/depth_upscaling.md
           - MoE-based Upscaling: algorithms/moe_based_upscaling.md
@@ -42,13 +56,22 @@ nav:
           - Weight-Ensembling MoE: algorithms/weight_ensembling_moe.md
           - PWE MoE: algorithms/pwe_moe.md
           - SMILE Upscaling: algorithms/smile_upscaling.md
-          # - Model Stitching: algorithms/model_stitching.md
+          - RankOne MoE: algorithms/rankone_moe.md
           - Model Recombination: algorithms/model_recombination.md
       - Model Compression:
           - Task Vector Compression:
               - BitDelta: algorithms/bitdelta.md
           - Parameter Pruning:
               - Magnitude Pruning: algorithms/pruning/magnitude_pruning.md
+              - SparseLo: algorithms/sparselo_pruning.md
+          - Expert/Model Pruning:
+              - MoE Pruner: algorithms/moe_pruner.md
+              - Expert Sparsity: algorithms/expert_sparsity.md
+      - Fine-tuning:
+          - Classification: algorithms/classification_finetune.md
+          - Language Models: algorithms/lm_finetune.md
+      - Analysis:
+          - Task Vector Analysis: algorithms/analysis_tools.md
   - Model Pool (Benchmark Models):
       - modelpool/README.md
       - Computer Vision Tasks:
@@ -77,7 +100,6 @@ nav:
       - Large Language Model:
           - Task Pool for Language Model Evaluation Harness: taskpool/lm_eval_harness.md
           - taskpool/lm_eval_harness_cli.md
-    # - fusion_bench: cli/fusion_bench.md
   - API Reference:
       - api/index.md
       - api/fusion_bench.mixins.md
@@ -102,6 +124,7 @@ nav:
           - api/fusion_bench.utils/torch.md
           - api/fusion_bench.utils/filesystem.md
           - api/fusion_bench.utils/modelscope.md
+          - api/fusion_bench.utils/misc.md
           - api/fusion_bench.utils/package_management.md
       - api/fusion_bench.models.md
       - api/fusion_bench.dataset.md
@@ -112,6 +135,9 @@ nav:
       - api/fusion_bench.compat.md
   - Guides:
       - guides/docs.md
+      - Extending FusionBench:
+          - Custom ModelPool: guides/custom_modelpool.md
+          - Custom TaskPool: guides/custom_taskpool.md
       - FusionBench Programming Guide:
           - Overview: guides/fusion_bench/README.md
           - Mixins:
@@ -127,9 +153,6 @@ nav:
       - Natural Language Processing:
           - Tasks:
               - guides/nlp/question_answering.md
-              # - Reading Lists:
-      # - readinglist/README.md
-      # - Mode Connectivity: readinglist/mode_connectivity.md
       - CLI Tools:
           - cli/fusion_bench.md
           - cli/fusion_bench_webui.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
           - Fisher Merging: algorithms/fisher_merging.md
           - Task Arithmetic: algorithms/task_arithmetic.md
           - Ties-Merging: algorithms/ties_merging.md
+          - MagMax: algorithms/magmax.md
           - AdaMerging: algorithms/adamerging.md
           - RegMean: algorithms/regmean.md
           - RegMean++: algorithms/regmean_plusplus.md

--- a/tests/test_magmax.py
+++ b/tests/test_magmax.py
@@ -1,0 +1,134 @@
+"""Tests for the MagMax model-merging algorithm.
+
+Cross-checked against the reference implementation
+(``tmp/magmax/src/merging/task_vectors.py::merge_max_abs``).
+"""
+
+import unittest
+from copy import deepcopy
+
+import torch
+import torch.nn as nn
+
+from fusion_bench.method.magmax import MagMaxAlgorithm, magmax_merge
+from fusion_bench.method.magmax.magmax import _magmax_select
+
+
+class TinyModel(nn.Module):
+    def __init__(self, in_dim=4, out_dim=3):
+        super().__init__()
+        self.linear = nn.Linear(in_dim, out_dim)
+
+
+def _reference_merge_max_abs(task_vectors):
+    """Direct port of ``merge_max_abs`` from the reference repo, used as a
+    ground-truth oracle for the FusionBench implementation."""
+    new_vector = {}
+    for key in task_vectors[0]:
+        max_abs_tensor = task_vectors[0][key].clone()
+        for tv in task_vectors[1:]:
+            current = tv[key]
+            max_abs_tensor = torch.where(
+                current.abs() >= max_abs_tensor.abs(), current, max_abs_tensor
+            )
+        new_vector[key] = max_abs_tensor
+    return new_vector
+
+
+class TestMagMaxSelect(unittest.TestCase):
+    def test_matches_reference_implementation(self):
+        torch.manual_seed(0)
+        tvs = [
+            {"w": torch.randn(5, 7), "b": torch.randn(5)}
+            for _ in range(4)
+        ]
+        oracle = _reference_merge_max_abs(tvs)
+        ours = _magmax_select(tvs)
+        for k in oracle:
+            self.assertTrue(torch.equal(oracle[k], ours[k]), msg=f"mismatch on key {k}")
+
+    def test_per_element_max_magnitude(self):
+        tv_a = {"w": torch.tensor([1.0, -2.0, 3.0])}
+        tv_b = {"w": torch.tensor([-4.0, 0.5, 2.0])}
+        tv_c = {"w": torch.tensor([0.0, -2.5, 3.0])}
+        out = _magmax_select([tv_a, tv_b, tv_c])
+        # max-abs values per index are: 4.0 (from b), 2.5 (from c), 3.0 (a or c)
+        expected = torch.tensor([-4.0, -2.5, 3.0])
+        self.assertTrue(torch.equal(out["w"], expected))
+
+    def test_tie_breaking_prefers_later(self):
+        # On ties (|a| == |b|), the reference uses '>=' so the LATER task wins.
+        tv_a = {"w": torch.tensor([1.0])}
+        tv_b = {"w": torch.tensor([-1.0])}
+        out = _magmax_select([tv_a, tv_b])
+        self.assertTrue(torch.equal(out["w"], torch.tensor([-1.0])))
+
+
+class TestMagMaxMerge(unittest.TestCase):
+    def test_merge_recovers_pretrained_plus_scaled_taumax(self):
+        torch.manual_seed(42)
+        pretrained = TinyModel()
+        finetuned = [deepcopy(pretrained) for _ in range(3)]
+        # Make each finetuned model differ from pretrained
+        for ft in finetuned:
+            with torch.no_grad():
+                for p in ft.parameters():
+                    p.add_(torch.randn_like(p) * 0.1)
+
+        scaling = 0.5
+        merged = magmax_merge(
+            deepcopy(pretrained), finetuned, scaling_factor=scaling, inplace=True
+        )
+
+        # Recompute expected merge via the reference path
+        ptm_sd = pretrained.state_dict()
+        tvs = [
+            {k: ft.state_dict()[k] - ptm_sd[k] for k in ptm_sd}
+            for ft in finetuned
+        ]
+        tau_max = _reference_merge_max_abs(tvs)
+        expected_sd = {k: ptm_sd[k] + scaling * tau_max[k] for k in ptm_sd}
+
+        for k, v in merged.state_dict().items():
+            self.assertTrue(
+                torch.allclose(v, expected_sd[k]), msg=f"mismatch on key {k}"
+            )
+
+    def test_scaling_factor_zero_returns_pretrained(self):
+        torch.manual_seed(1)
+        pretrained = TinyModel()
+        finetuned = [TinyModel() for _ in range(3)]
+        original_sd = {k: v.clone() for k, v in pretrained.state_dict().items()}
+        merged = magmax_merge(
+            deepcopy(pretrained), finetuned, scaling_factor=0.0, inplace=True
+        )
+        for k, v in merged.state_dict().items():
+            self.assertTrue(torch.allclose(v, original_sd[k]))
+
+
+class TestMagMaxAlgorithm(unittest.TestCase):
+    def test_run_against_dict_modelpool(self):
+        torch.manual_seed(7)
+        pretrained = TinyModel()
+        models = {"_pretrained_": deepcopy(pretrained)}
+        for i in range(3):
+            ft = deepcopy(pretrained)
+            with torch.no_grad():
+                for p in ft.parameters():
+                    p.add_(torch.randn_like(p) * 0.05 * (i + 1))
+            models[f"task_{i}"] = ft
+
+        algo = MagMaxAlgorithm(scaling_factor=0.5, inplace=False)
+        merged = algo.run(models)
+
+        # Same expected output as the direct function call.
+        finetuned = [models[f"task_{i}"] for i in range(3)]
+        expected = magmax_merge(
+            deepcopy(pretrained), finetuned, scaling_factor=0.5, inplace=False
+        )
+        for k, v in merged.state_dict().items():
+            self.assertTrue(torch.allclose(v, expected.state_dict()[k]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add MagMax (Marczak et al., ECCV 2024, arXiv:2407.06322): element-wise maximum-magnitude task-vector selection. Matches the reference implementation bit-for-bit (>= tie-break, skips integer/bool buffers).

Includes:
- Algorithm + standalone magmax_merge helper
- Hydra config and lazy-import registration
- examples/magmax/: ind-ft shell scripts and a paper-faithful seq-ft reproduction script (sequential_ft_and_merge.py) that trains the 8 per-task snapshots itself before merging
- docs/algorithms/magmax.md (linked from mkdocs nav) with both ind-ft and seq-ft reproduction tables on CLIP-ViT-B/32 TA8
- tests/test_magmax.py: 6 unit tests, including bit-exact equivalence against a direct port of the reference merge_max_abs